### PR TITLE
Add support for new API Gateway service.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ _Client constructor supports the following mandatory parameters:_
 
 Client constructor will read values for the `apihost`, `namespace`, `api_key`, `apigw_token` and `apigw_space_guid` options from the environment if the following parameters are set. Explicit options have precedence over environment values.
 
-- *\_\_OW_API_HOST*
-- *\_\_OW_NAMESPACE*
+- *__OW_API_HOST*
+- *__OW_NAMESPACE*
 - *__OW_API_KEY*
 - *__OW_APIGW_TOKEN*
 - *__OW_APIGW_SPACE_SUID*
@@ -419,7 +419,7 @@ The following optional parameters are supported:
 
 ## api gateway
 
-OpenWhisk supports a [built-in API gateway service](https://github.com/openwhisk/openwhisk/blob/master/docs/apigateway.md) and external third-party providers. 
+OpenWhisk supports a [built-in API gateway service](https://github.com/apache/incubator-openwhisk/blob/master/docs/apigateway.md) and external third-party providers. 
 
 This client library defaults to using the platform service. If the `apigw_token` parameter is passed into the client constructor, the implementation will switch to the [IBM Bluemix API Gateway](https://console.ng.bluemix.net/docs/openwhisk/openwhisk_apigateway.html#openwhisk_apigateway). 
 

--- a/README.md
+++ b/README.md
@@ -68,16 +68,19 @@ _Client constructor supports the following mandatory parameters:_
 
 - **api.** Full API URL for OpenWhisk platform, e.g. `https://openwhisk.ng.bluemix.net/api/v1/`. This value overrides `apihost` if both are present.
 - **namespace**. Namespace for resource requests, defaults to `_`.
-
 - **ignore_certs**. Turns off server SSL/TLS certificate verification. This allows the client to be used against local deployments of OpenWhisk with a self-signed certificate. Defaults to false.
+- **apigw_token**. API Gateway service authentication token. This is mandatory for using an external API Gateway service, rather than the built-in api gateway.
+- **apigw_space_guid**. API Gateway space identifier. This is optional when using an API gateway service, defaults to the authentication uuid.
 
 ### environment variables
 
-Client constructor will read values for the `apihost`, `namespace` and `api_key` options from the environment if the following parameters are set. Explicit parameter values override these values.
+Client constructor will read values for the `apihost`, `namespace`, `api_key`, `apigw_token` and `apigw_space_guid` options from the environment if the following parameters are set. Explicit options have precedence over environment values.
 
 - *\_\_OW_API_HOST*
 - *\_\_OW_NAMESPACE*
 - *__OW_API_KEY*
+- *__OW_APIGW_TOKEN*
+- *__OW_APIGW_SPACE_SUID*
 
 
 
@@ -414,9 +417,13 @@ The following optional parameters are supported:
 - `namespace` - set custom namespace for endpoint
 - `params` - JSON object containing parameters for the feed being invoked (default: `{}`)
 
-## api gateway (experimental)
+## api gateway
 
-*[API Gateway support](https://github.com/openwhisk/openwhisk/blob/master/docs/apigateway.md) is currently experimental and may be subject to breaking changes.*
+OpenWhisk supports a [built-in API gateway service](https://github.com/openwhisk/openwhisk/blob/master/docs/apigateway.md) and external third-party providers. 
+
+This client library defaults to using the platform service. If the `apigw_token` parameter is passed into the client constructor, the implementation will switch to the [IBM Bluemix API Gateway](https://console.ng.bluemix.net/docs/openwhisk/openwhisk_apigateway.html#openwhisk_apigateway). 
+
+*The interface for managing routes through the library does not change between providers.* 
 
 ### list routes
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -18,13 +18,22 @@ class Client {
     const api = options.api ||
       this.url_from_apihost(options.apihost || process.env['__OW_API_HOST'])
 
+    // optional tokens for API GW service
+    const apigw_token = options.apigw_token || process.env['__OW_APIGW_TOKEN']
+    let apigw_space_guid = options.apigw_space_guid || process.env['__OW_APIGW_SPACE_GUID']
+
+    // unless space is explicitly passed, default to using auth uuid.
+    if (apigw_token && !apigw_space_guid) {
+      apigw_space_guid = api_key.split(':')[0]
+    }
+
     if (!api_key) {
       throw new Error(`${messages.INVALID_OPTIONS_ERROR} Missing api_key parameter.`)
     } else if (!api) {
       throw new Error(`${messages.INVALID_OPTIONS_ERROR} Missing either api or apihost parameters.`)
     }
 
-    return {api_key, api, ignore_certs, namespace: options.namespace}
+    return {api_key, api, ignore_certs, namespace: options.namespace, apigw_token, apigw_space_guid}
   }
 
   url_from_apihost (apihost) {

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -6,14 +6,27 @@ const names = require('./names')
 const CREATE_PARAMS = ['relpath', 'operation', 'action']
 
 class Routes extends BaseOperation {
-  static get routeMgmtApiPath () {
-    return 'experimental/web/whisk.system/routemgmt'
+  routeMgmtApiPath (path) {
+    return this.has_access_token() ?
+      `web/whisk.system/apimgmt/${path}.http` :
+      `experimental/web/whisk.system/routemgmt/${path}.json`
   }
 
   list (options) {
     options = options || {}
     const qs = this.qs(options, ['relpath', 'basepath', 'operation', 'limit', 'skip'])
-    return this.client.request('GET', `${Routes.routeMgmtApiPath}/getApi.json`, { qs })
+    return this.client.request('GET', this.routeMgmtApiPath('getApi'), { qs })
+  }
+
+  qs (options, names) {
+    const result = super.qs(options, names)
+
+    if (this.has_access_token()) {
+      result.accesstoken = this.client.options.apigw_token
+      result.spaceguid = this.client.options.apigw_space_guid
+    }
+
+    return result
   }
 
   delete (options) {
@@ -23,7 +36,7 @@ class Routes extends BaseOperation {
 
     const qs = this.qs(options, ['relpath', 'basepath', 'operation'])
     qs.force = true
-    return this.client.request('DELETE', `${Routes.routeMgmtApiPath}/deleteApi.json`, { qs })
+    return this.client.request('DELETE', this.routeMgmtApiPath('deleteApi'), { qs })
   }
 
   create (options) {
@@ -34,7 +47,8 @@ class Routes extends BaseOperation {
     }
 
     const body = this.route_swagger_definition(options)
-    return this.client.request('POST', `${Routes.routeMgmtApiPath}/createApi.json`, { body })
+    const qs = this.qs(options, [])
+    return this.client.request('POST', this.routeMgmtApiPath('createApi'), { body, qs })
   }
 
   route_swagger_definition (params) {
@@ -59,7 +73,7 @@ class Routes extends BaseOperation {
     return {
       name: id,
       namespace: namespace,
-      backendMethod: 'POST',
+      backendMethod: this.action_url_method(),
       backendUrl: this.action_url_path(id, namespace),
       authkey: this.client.options.api_key
     }
@@ -69,9 +83,26 @@ class Routes extends BaseOperation {
     return params.basepath || '/'
   }
 
+  action_url_method () {
+    return this.has_access_token() ? 'GET' : 'POST'
+  }
+
   action_url_path (id, namespace) {
-    const path = `namespaces/${namespace}/actions/${id}`
-    return this.client.path_url(path)
+    if (!this.has_access_token()) {
+      return this.client.path_url(`namespaces/${namespace}/actions/${id}`)
+    }
+
+    // web action path must contain package identifier. uses default for
+    // non-explicit package.
+    if (!id.includes('/')) {
+      id = `default/${id}`
+    }
+
+    return this.client.path_url(`web/${namespace}/${id}.http`)
+  }
+
+  has_access_token () {
+    return !!this.client.options.apigw_token
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openwhisk",
-  "version": "3.5.1",
+  "version": "3.6.0",
   "description": "JavaScript client library for the OpenWhisk platform",
   "main": "lib/main.js",
   "engines": {

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -3,13 +3,12 @@ Integrations Test
 
 Running the integration tests requires the following environment variables to be defined.
 
-    export OW_API_KEY=<your api key>
-    export OW_API_URL=<openwhisk API url>
-    export __OW_NAMESPACE=<namespace to test against>
+    export __OW_API_KEY=<your api key>
+    export __OW_API_HOST=<openwhisk API hostname>
+    export __OW_NAMESPACE=<openwhisk namespace>
+    export __OW_APIGW_TOKEN=<api gateway token>
 
-You can retrieve these settings using the `wsk` CLI:
-
-    wsk property get --all
+You can retrieve these settings from the `.wskprops` file.
 
 Further, you need to create the following seed artifacts.
 

--- a/test/integration/activations.test.js
+++ b/test/integration/activations.test.js
@@ -4,26 +4,20 @@ const test = require('ava')
 const Activations = require('../../lib/activations.js')
 const Client = require('../../lib/client.js')
 
-const API_KEY = process.env.OW_API_KEY
-const API_URL = process.env.OW_API_URL
-const NAMESPACE = process.env['__OW_NAMESPACE']
+const envParams = ['API_KEY', 'API_HOST', 'NAMESPACE']
 
-if (!API_KEY) {
-  throw new Error('Missing OW_API_KEY environment parameter')
-}
+// check that mandatory configuration properties are available
+envParams.forEach(key => {
+  const param = `__OW_${key}` 
+  if (!process.env.hasOwnProperty(param)) {
+    throw new Error(`Missing ${param} environment parameter`)
+  }
+})
 
-if (!API_URL) {
-  throw new Error('Missing OW_API_URL environment parameter')
-}
-
-if (!NAMESPACE) {
-  throw new Error('Missing __OW_NAMESPACE environment parameter')
-}
+const NAMESPACE = process.env.__OW_NAMESPACE
 
 test('list all activations', t => {
-  const params = {api: API_URL, api_key: API_KEY, namespace: NAMESPACE}
-
-  const activations = new Activations(new Client(params))
+  const activations = new Activations(new Client())
   return activations.list().then(result => {
     t.true(Array.isArray(result))
     result.forEach(r => t.is(r.namespace, NAMESPACE))
@@ -35,9 +29,7 @@ test('list all activations', t => {
 })
 
 test('retrieve individual activations', t => {
-  const params = {api: API_URL, api_key: API_KEY, namespace: NAMESPACE}
-
-  const activations = new Activations(new Client(params))
+  const activations = new Activations(new Client())
   return activations.list().then(result => {
     t.true(Array.isArray(result))
     return Promise.all(result.map(r => activations.get({activation: r.activationId})))
@@ -48,9 +40,7 @@ test('retrieve individual activations', t => {
 })
 
 test('retrieve individual activation logs', t => {
-  const params = {api: API_URL, api_key: API_KEY, namespace: NAMESPACE}
-
-  const activations = new Activations(new Client(params))
+  const activations = new Activations(new Client())
   return activations.list().then(result => {
     t.true(Array.isArray(result))
     return Promise.all(result.map(r => activations.logs({activation: r.activationId})))
@@ -61,9 +51,7 @@ test('retrieve individual activation logs', t => {
 })
 
 test('retrieve individual activation result', t => {
-  const params = {api: API_URL, api_key: API_KEY, namespace: NAMESPACE}
-
-  const activations = new Activations(new Client(params))
+  const activations = new Activations(new Client())
   return activations.list().then(result => {
     t.true(Array.isArray(result))
     return Promise.all(result.map(r => activations.result({activation: r.activationId})))

--- a/test/integration/feeds.test.js
+++ b/test/integration/feeds.test.js
@@ -5,32 +5,26 @@ const Feeds = require('../../lib/feeds.js')
 const Triggers = require('../../lib/triggers.js')
 const Client = require('../../lib/client.js')
 
-const API_KEY = process.env.OW_API_KEY
-const API_URL = process.env.OW_API_URL
-const NAMESPACE = process.env['__OW_NAMESPACE']
+const envParams = ['API_KEY', 'API_HOST', 'NAMESPACE']
 
-if (!API_KEY) {
-  throw new Error('Missing OW_API_KEY environment parameter')
-}
+// check that mandatory configuration properties are available
+envParams.forEach(key => {
+  const param = `__OW_${key}` 
+  if (!process.env.hasOwnProperty(param)) {
+    throw new Error(`Missing ${param} environment parameter`)
+  }
+})
 
-if (!API_URL) {
-  throw new Error('Missing OW_API_URL environment parameter')
-}
-
-if (!NAMESPACE) {
-  throw new Error('Missing OW_NAMESPACE environment parameter')
-}
+const NAMESPACE = process.env.__OW_NAMESPACE
 
 test('create and delete a feed', t => {
-  const params = {api: API_URL, api_key: API_KEY, namespace: NAMESPACE}
-
   const errors = err => {
     console.log(err)
     t.fail()
   }
 
-  const feeds = new Feeds(new Client(params))
-  const triggers = new Triggers(new Client(params))
+  const feeds = new Feeds(new Client())
+  const triggers = new Triggers(new Client())
   const feed_params = {
     feedName: '/whisk.system/alarms/alarm',
     trigger: `/${NAMESPACE}/sample_feed_trigger`,

--- a/test/integration/namespaces.test.js
+++ b/test/integration/namespaces.test.js
@@ -4,26 +4,20 @@ const test = require('ava')
 const Namespaces = require('../../lib/namespaces.js')
 const Client = require('../../lib/client.js')
 
-const API_KEY = process.env.OW_API_KEY
-const API_URL = process.env.OW_API_URL
-const NAMESPACE = process.env['__OW_NAMESPACE']
+const envParams = ['API_KEY', 'API_HOST', 'NAMESPACE']
 
-if (!API_KEY) {
-  throw new Error('Missing OW_API_KEY environment parameter')
-}
+// check that mandatory configuration properties are available
+envParams.forEach(key => {
+  const param = `__OW_${key}` 
+  if (!process.env.hasOwnProperty(param)) {
+    throw new Error(`Missing ${param} environment parameter`)
+  }
+})
 
-if (!API_URL) {
-  throw new Error('Missing OW_API_URL environment parameter')
-}
-
-if (!NAMESPACE) {
-  throw new Error('Missing OW_NAMESPACE environment parameter')
-}
+const NAMESPACE = process.env.__OW_NAMESPACE
 
 test('list all namespaces', t => {
-  const params = {api: API_URL, api_key: API_KEY}
-
-  const namespaces = new Namespaces(new Client(params))
+  const namespaces = new Namespaces(new Client())
   return namespaces.list().then(result => {
     t.true(Array.isArray(result))
     t.pass()
@@ -34,9 +28,7 @@ test('list all namespaces', t => {
 })
 
 test('retrieve individual namespaces', t => {
-  const params = {api: API_URL, api_key: API_KEY}
-
-  const namespaces = new Namespaces(new Client(params))
+  const namespaces = new Namespaces(new Client())
   return namespaces.list().then(result => {
     t.true(Array.isArray(result))
     return Promise.all(result.map(ns => namespaces.get({namespace: ns})))

--- a/test/integration/packages.test.js
+++ b/test/integration/packages.test.js
@@ -4,26 +4,20 @@ const test = require('ava')
 const Packages = require('../../lib/packages.js')
 const Client = require('../../lib/client.js')
 
-const API_KEY = process.env.OW_API_KEY
-const API_URL = process.env.OW_API_URL
-const NAMESPACE = process.env['__OW_NAMESPACE']
+const envParams = ['API_KEY', 'API_HOST', 'NAMESPACE']
 
-if (!API_KEY) {
-  throw new Error('Missing OW_API_KEY environment parameter')
-}
+// check that mandatory configuration properties are available
+envParams.forEach(key => {
+  const param = `__OW_${key}` 
+  if (!process.env.hasOwnProperty(param)) {
+    throw new Error(`Missing ${param} environment parameter`)
+  }
+})
 
-if (!API_URL) {
-  throw new Error('Missing OW_API_URL environment parameter')
-}
-
-if (!NAMESPACE) {
-  throw new Error('Missing OW_NAMESPACE environment parameter')
-}
+const NAMESPACE = process.env.__OW_NAMESPACE
 
 test('list all packages using default namespace', t => {
-  const params = {api: API_URL, api_key: API_KEY, namespace: NAMESPACE}
-
-  const packages = new Packages(new Client(params))
+  const packages = new Packages(new Client())
   return packages.list().then(result => {
     t.true(Array.isArray(result))
     result.forEach(packageName => {
@@ -37,9 +31,7 @@ test('list all packages using default namespace', t => {
 })
 
 test('list all packages using options namespace', t => {
-  const params = {api: API_URL, api_key: API_KEY}
-
-  const packages = new Packages(new Client(params))
+  const packages = new Packages(new Client())
   return packages.list({namespace: NAMESPACE}).then(result => {
     t.true(Array.isArray(result))
     result.forEach(packageName => {
@@ -53,14 +45,12 @@ test('list all packages using options namespace', t => {
 })
 
 test('create, get and delete an package', t => {
-  const params = {api: API_URL, api_key: API_KEY, namespace: NAMESPACE}
-
   const errors = err => {
     console.log(err)
     t.fail()
   }
 
-  const packages = new Packages(new Client(params))
+  const packages = new Packages(new Client())
   return packages.create({packageName: 'random_package_test'}).then(result => {
     t.is(result.name, 'random_package_test')
     t.is(result.namespace, NAMESPACE)
@@ -76,14 +66,12 @@ test('create, get and delete an package', t => {
 })
 
 test('create and update an package', t => {
-  const params = {api: API_URL, api_key: API_KEY, namespace: NAMESPACE}
-
   const errors = err => {
     console.log(err)
     t.fail()
   }
 
-  const packages = new Packages(new Client(params))
+  const packages = new Packages(new Client())
   return packages.create({packageName: 'random_package_update_test'}).then(result => {
     t.is(result.name, 'random_package_update_test')
     t.is(result.namespace, NAMESPACE)

--- a/test/integration/routes.test.js
+++ b/test/integration/routes.test.js
@@ -5,27 +5,22 @@ const Actions = require('../../lib/actions.js')
 const Routes = require('../../lib/routes.js')
 const Client = require('../../lib/client.js')
 
-const API_KEY = process.env.OW_API_KEY
-const API_URL = process.env.OW_API_URL
-const NAMESPACE = process.env['__OW_NAMESPACE']
+const envParams = ['API_KEY', 'API_HOST', 'APIGW_TOKEN']
 
-if (!API_KEY) {
-  throw new Error('Missing OW_API_KEY environment parameter')
-}
+// check that mandatory configuration properties are available
+envParams.forEach(key => {
+  const param = `__OW_${key}` 
+  if (!process.env.hasOwnProperty(param)) {
+    throw new Error(`Missing ${param} environment parameter`)
+  }
+})
 
-if (!API_URL) {
-  throw new Error('Missing OW_API_URL environment parameter')
-}
-
-if (!NAMESPACE) {
-  throw new Error('Missing OW_NAMESPACE environment parameter')
-}
-
-test('create, retrieve and delete action route', t => {
-  const params = {api: API_URL, api_key: API_KEY}
-
-  const routes = new Routes(new Client(params))
-  const actions = new Actions(new Client(params))
+test.serial('create, retrieve and delete action route', t => {
+  const token = process.env.__OW_APIGW_TOKEN
+  delete process.env.__OW_APIGW_TOKEN
+  const routes = new Routes(new Client())
+  const actions = new Actions(new Client())
+  process.env.__OW_APIGW_TOKEN = token
 
   return actions.create({actionName: 'routeAction', action: ''}).then(() => {
     return routes.create({action: 'routeAction', basepath: '/testing', relpath: '/foo/bar', operation: 'POST'}).then(() => {
@@ -37,6 +32,30 @@ test('create, retrieve and delete action route', t => {
         const path = apidoc.paths['/foo/bar']
         t.true(path.hasOwnProperty('post'))
         t.is(path.post['x-ibm-op-ext'].actionName, 'routeAction')
+
+        return routes.delete({basepath: '/testing'}).then(() => actions.delete({actionName: 'routeAction'}))
+      })
+    })
+  }).catch(err => {
+    console.log(err)
+    t.fail()
+  })
+})
+
+test.serial('create, retrieve and delete action route using token', t => {
+  const routes = new Routes(new Client())
+  const actions = new Actions(new Client())
+
+  return actions.create({actionName: 'routeAction', action: ''}).then(() => {
+    return routes.create({action: 'routeAction', basepath: '/testing', relpath: '/foo/bar', operation: 'POST'}).then(() => {
+      return routes.list({basepath: '/testing'}).then(results => {
+        t.is(results.apis.length, 1)
+        const apidoc = results.apis[0].value.apidoc
+        t.is(apidoc.basePath, '/testing')
+        t.true(apidoc.paths.hasOwnProperty('/foo/bar'))
+        const path = apidoc.paths['/foo/bar']
+        t.true(path.hasOwnProperty('post'))
+        t.is(path.post['x-openwhisk'].action, 'routeAction')
 
         return routes.delete({basepath: '/testing'}).then(() => actions.delete({actionName: 'routeAction'}))
       })

--- a/test/integration/rules.test.js
+++ b/test/integration/rules.test.js
@@ -5,26 +5,20 @@ const Rules = require('../../lib/rules.js')
 const Triggers = require('../../lib/triggers.js')
 const Client = require('../../lib/client.js')
 
-const API_KEY = process.env.OW_API_KEY
-const API_URL = process.env.OW_API_URL
-const NAMESPACE = process.env['__OW_NAMESPACE']
+const envParams = ['API_KEY', 'API_HOST', 'NAMESPACE']
 
-if (!API_KEY) {
-  throw new Error('Missing OW_API_KEY environment parameter')
-}
+// check that mandatory configuration properties are available
+envParams.forEach(key => {
+  const param = `__OW_${key}` 
+  if (!process.env.hasOwnProperty(param)) {
+    throw new Error(`Missing ${param} environment parameter`)
+  }
+})
 
-if (!API_URL) {
-  throw new Error('Missing OW_API_URL environment parameter')
-}
-
-if (!NAMESPACE) {
-  throw new Error('Missing OW_NAMESPACE environment parameter')
-}
+const NAMESPACE = process.env.__OW_NAMESPACE
 
 test('list all rules using default namespace', t => {
-  const params = {api: API_URL, api_key: API_KEY, namespace: NAMESPACE}
-
-  const rules = new Rules(new Client(params))
+  const rules = new Rules(new Client())
   return rules.list().then(result => {
     t.true(Array.isArray(result))
     result.forEach(rule => {
@@ -38,9 +32,7 @@ test('list all rules using default namespace', t => {
 })
 
 test('list all rules using options namespace', t => {
-  const params = {api: API_URL, api_key: API_KEY}
-
-  const rules = new Rules(new Client(params))
+  const rules = new Rules(new Client())
   return rules.list({namespace: NAMESPACE}).then(result => {
     t.true(Array.isArray(result))
     result.forEach(rule => {
@@ -55,15 +47,13 @@ test('list all rules using options namespace', t => {
 
 // Running update tests conconcurrently leads to resource conflict errors.
 test.serial('create, get and delete a rule', t => {
-  const params = {api: API_URL, api_key: API_KEY, namespace: NAMESPACE}
-
   const errors = err => {
     console.log(err)
     t.fail()
   }
 
-  const rules = new Rules(new Client(params))
-  const triggers = new Triggers(new Client(params))
+  const rules = new Rules(new Client())
+  const triggers = new Triggers(new Client())
   return triggers.create({triggerName: 'sample_rule_trigger'}).then(() => {
     return rules.create({ruleName: 'random_rule_test', action: `/${NAMESPACE}/hello`, trigger: `/${NAMESPACE}/sample_rule_trigger`}).then(result => {
       t.is(result.name, 'random_rule_test')
@@ -83,15 +73,13 @@ test.serial('create, get and delete a rule', t => {
 })
 
 test.serial('create and update a rule', t => {
-  const params = {api: API_URL, api_key: API_KEY, namespace: NAMESPACE}
-
   const errors = err => {
     console.log(err)
     t.fail()
   }
 
-  const rules = new Rules(new Client(params))
-  const triggers = new Triggers(new Client(params))
+  const rules = new Rules(new Client())
+  const triggers = new Triggers(new Client())
   return triggers.create({triggerName: 'sample_rule_trigger'}).then(() => {
     return rules.create({ruleName: 'random_update_test', action: `/${NAMESPACE}/hello`, trigger: `/${NAMESPACE}/sample_rule_trigger`}).then(result => {
       t.is(result.name, 'random_update_test')

--- a/test/integration/triggers.test.js
+++ b/test/integration/triggers.test.js
@@ -4,26 +4,20 @@ const test = require('ava')
 const Triggers = require('../../lib/triggers.js')
 const Client = require('../../lib/client.js')
 
-const API_KEY = process.env.OW_API_KEY
-const API_URL = process.env.OW_API_URL
-const NAMESPACE = process.env['__OW_NAMESPACE']
+const envParams = ['API_KEY', 'API_HOST', 'NAMESPACE']
 
-if (!API_KEY) {
-  throw new Error('Missing OW_API_KEY environment parameter')
-}
+// check that mandatory configuration properties are available
+envParams.forEach(key => {
+  const param = `__OW_${key}` 
+  if (!process.env.hasOwnProperty(param)) {
+    throw new Error(`Missing ${param} environment parameter`)
+  }
+})
 
-if (!API_URL) {
-  throw new Error('Missing OW_API_URL environment parameter')
-}
-
-if (!NAMESPACE) {
-  throw new Error('Missing OW_NAMESPACE environment parameter')
-}
+const NAMESPACE = process.env.__OW_NAMESPACE
 
 test('list all triggers using default namespace', t => {
-  const params = {api: API_URL, api_key: API_KEY, namespace: NAMESPACE}
-
-  const triggers = new Triggers(new Client(params))
+  const triggers = new Triggers(new Client())
   return triggers.list().then(result => {
     t.true(Array.isArray(result))
     result.forEach(trigger => {
@@ -37,9 +31,7 @@ test('list all triggers using default namespace', t => {
 })
 
 test('list all triggers using options namespace', t => {
-  const params = {api: API_URL, api_key: API_KEY}
-
-  const triggers = new Triggers(new Client(params))
+  const triggers = new Triggers(new Client())
   return triggers.list({namespace: NAMESPACE}).then(result => {
     t.true(Array.isArray(result))
     result.forEach(trigger => {
@@ -53,14 +45,12 @@ test('list all triggers using options namespace', t => {
 })
 
 test('create, get and delete an trigger', t => {
-  const params = {api: API_URL, api_key: API_KEY, namespace: NAMESPACE}
-
   const errors = err => {
     console.log(err)
     t.fail()
   }
 
-  const triggers = new Triggers(new Client(params))
+  const triggers = new Triggers(new Client())
   return triggers.create({triggerName: 'random_trigger_test'}).then(result => {
     t.is(result.name, 'random_trigger_test')
     t.is(result.namespace, NAMESPACE)
@@ -78,14 +68,12 @@ test('create, get and delete an trigger', t => {
 })
 
 test('create and update an trigger', t => {
-  const params = {api: API_URL, api_key: API_KEY, namespace: NAMESPACE}
-
   const errors = err => {
     console.log(err)
     t.fail()
   }
 
-  const triggers = new Triggers(new Client(params))
+  const triggers = new Triggers(new Client())
   return triggers.create({triggerName: 'random_create_update_test'}).then(result => {
     t.is(result.name, 'random_create_update_test')
     t.is(result.namespace, NAMESPACE)
@@ -101,14 +89,12 @@ test('create and update an trigger', t => {
 })
 
 test('fire a trigger', t => {
-  const params = {api: API_URL, api_key: API_KEY, namespace: NAMESPACE}
-
   const errors = err => {
     console.log(err)
     t.fail()
   }
 
-  const triggers = new Triggers(new Client(params))
+  const triggers = new Triggers(new Client())
   return triggers.create({triggerName: 'random_fire_test'}).then(result => {
     return triggers.invoke({triggerName: 'random_fire_test'}).then(update_result => {
       t.true(update_result.hasOwnProperty('activationId'))

--- a/test/unit/client.test.js
+++ b/test/unit/client.test.js
@@ -13,30 +13,49 @@ test('should use default constructor options', t => {
 })
 
 test('should support explicit constructor options', t => {
-  const client = new Client({namespace: 'ns', ignore_certs: true, api_key: 'aaa', api: 'my_host'})
+  const client = new Client({namespace: 'ns', ignore_certs: true, api_key: 'aaa', api: 'my_host', apigw_token: 'oauth_token', apigw_space_guid: 'space_guid'})
   t.is(client.options.api, 'my_host')
   t.true(client.options.ignore_certs)
   t.is(client.options.namespace, 'ns')
+  t.is(client.options.apigw_token, 'oauth_token')
+  t.is(client.options.apigw_space_guid, 'space_guid')
+})
+
+test('should use uuid from auth key as space guid if apigw_token present', t => {
+  const client = new Client({namespace: 'ns', ignore_certs: true, api_key: 'uuid:pass', api: 'my_host', apigw_token: 'oauth_token'})
+  t.is(client.options.apigw_space_guid, 'uuid')
 })
 
 test('should use environment parameters for options if not set explicitly.', t => {
   process.env['__OW_API_KEY'] = 'some_user:some_pass'
   process.env['__OW_API_HOST'] = 'mywhiskhost'
+  process.env['__OW_APIGW_TOKEN'] = 'my-token'
+  process.env['__OW_APIGW_SPACE_GUID'] = 'my-space'
   const client = new Client()
   t.is(client.options.api_key, process.env['__OW_API_KEY'])
   t.is(client.options.api, 'https://mywhiskhost/api/v1/')
+  t.is(client.options.apigw_token, 'my-token')
+  t.is(client.options.apigw_space_guid, 'my-space')
   delete process.env['__OW_API_KEY']
   delete process.env['__OW_API_HOST']
+  delete process.env['__OW_APIGW_TOKEN']
+  delete process.env['__OW_APIGW_SPACE_GUID']
 })
 
 test('should use options for parameters even if environment parameters are available.', t => {
   process.env['__OW_API_KEY'] = 'some_user:some_pass'
   process.env['__OW_API_HOST'] = 'mywhiskhost'
-  const client = new Client({apihost: 'openwhisk', api_key: 'mykey'})
+  process.env['__OW_APIGW_TOKEN'] = 'my-token'
+  process.env['__OW_APIGW_SPACE_GUID'] = 'my-space'
+  const client = new Client({apihost: 'openwhisk', api_key: 'mykey', apigw_token: 'token', apigw_space_guid: 'guid'})
   t.is(client.options.api_key, 'mykey')
   t.is(client.options.api, 'https://openwhisk/api/v1/')
+  t.is(client.options.apigw_token, 'token')
+  t.is(client.options.apigw_space_guid, 'guid')
   delete process.env['__OW_API_KEY']
   delete process.env['__OW_API_HOST']
+  delete process.env['__OW_APIGW_TOKEN']
+  delete process.env['__OW_APIGW_SPACE_GUID']
 })
 
 test('should throw error when missing API key option.', t => {


### PR DESCRIPTION
Supports passing token will switch to using provider implementation rather than built-in platform service.

Add unit tests and verified integrations still work against the current platform.