### PR TITLE
removed the experimental from API Url.

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -12,7 +12,7 @@ class Routes extends BaseOperation {
   routeMgmtApiPath (path) {
     return this.has_access_token() ?
       `web/whisk.system/apimgmt/${path}.http` :
-      `experimental/web/whisk.system/routemgmt/${path}.json`
+      `web/whisk.system/routemgmt/${path}.json`
   }
 
   list (options) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openwhisk",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "description": "JavaScript client library for the OpenWhisk platform",
   "main": "lib/main.js",
   "engines": {

--- a/test/unit/routes.test.js
+++ b/test/unit/routes.test.js
@@ -9,7 +9,7 @@ const Routes = require('../../lib/routes')
 test('should return experimental api path without api token', t => {
   const client = { options: {} }
   const routes = new Routes(client)
-  t.is(routes.routeMgmtApiPath('a'), 'experimental/web/whisk.system/routemgmt/a.json')
+  t.is(routes.routeMgmtApiPath('a'), 'web/whisk.system/routemgmt/a.json')
 })
 
 test('should return experimental api path with api token', t => {


### PR DESCRIPTION
  During my tests with the serverless framework i discovered that an experimental marked url. was not working anymore. 
So i looked at the wsk util and discovered that wsk uses to do the same thing, a related url without the experimental.

Thx in advance
meno