### PR TITLE
code coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 node_modules
 npm-debug.log
 .DS_Store
+coverage
+.nyc_output
+ecma5
+.DS_STORE
+package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage
 ecma5
 .DS_STORE
 package-lock.json
+coverage.lcov

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,4 @@ install:
 script:
   - ./tools/travis/scancode.sh
   - cd $TRAVIS_BUILD_DIR
-  - ./tools/travis/unit.sh
-  - cd $TRAVIS_BUILD_DIR
-  - ./tools/travis/integration.sh
+  - ./tools/travis/build.sh

--- a/README.md
+++ b/README.md
@@ -510,4 +510,19 @@ Run the script with specific credentials:
 ```
 ./test/integration/prepIntegrationTests.sh <your key in the form of ABCD:EFGH> <openwhisk instance hostname> <openwhisk namespace> <api gatewaytoken>
 ```  
-The `prepIntegrationTests.sh` script is designed to give you feedback if it detects a setting that is not correct on your machine. ex: `node 6 is not detected`
+The `prepIntegrationTests.sh` script is designed to give you feedback if it detects a setting that is not correct on your machine. ex: `node 6 or above is not detected`
+
+## Code-Coverage:
+
+You can customize how comprehensive the tests are over the code, and generate reports to view the results by using
+the provided `code-coverage` commands below.  
+
+**Note:** Ensure that you use guest credentials with the wsk CLI.  
+
+To compile down to ECMA5 run the following command:  
+1 `npm run code-coverage-build`  
+
+To generate combined reports of both the unit and integration tests, run the following command:  
+2 `npm run code-coverage-run`  
+
+The report is viewable under `/coverage`. Click **`/coverage/index.html`** to view the full report.  

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://travis-ci.org/apache/incubator-openwhisk-client-js.svg?branch=master)](https://travis-ci.org/apache/incubator-openwhisk-client-js)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
+[![codecov](https://codecov.io/gh/apache/incubator-openwhisk-client-js/branch/master/graph/badge.svg)](https://codecov.io/gh/apache/incubator-openwhisk-client-js)
 
 JavaScript client library for the [Apache OpenWhisk](https://github.com/apache/incubator-openwhisk) platform.
 Provides a wrapper around the [OpenWhisk APIs](https://github.com/apache/incubator-openwhisk/blob/fb001afa237476eda0c0f6494ee92702e5986538/core/controller/src/main/resources/apiv1swagger.json) (Swagger JSON).

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test": "ava test/unit",
     "test-integration": "ava test/integration/*.test.js",
     "code-coverage-build": "babel --out-dir=ecma5 lib",
-    "code-coverage-run": "./tools/merge-coverage.sh"
+    "code-coverage-run": "./tools/merge-coverage.sh",
+    "coverage": "nyc report --reporter=text-lcov > coverage.lcov && codecov"
   },
   "repository": {
     "type": "git",
@@ -34,6 +35,7 @@
     "ava": "^0.15.2",
     "babel": "^6.23.0",
     "babel-cli": "^6.24.1",
+    "codecov": "^2.3.0",
     "jszip": "^3.1.3",
     "nyc": "^11.0.3",
     "proxyquire": "1.7.4"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
   },
   "scripts": {
     "test": "ava test/unit",
-    "test-integration": "ava test/integration/*.test.js"
+    "test-integration": "ava test/integration/*.test.js",
+    "code-coverage-build": "babel --out-dir=ecma5 lib",
+    "code-coverage-run": "./tools/merge-coverage.sh"
   },
   "repository": {
     "type": "git",
@@ -30,10 +32,32 @@
   "homepage": "https://github.com/openwhisk/openwhisk-client-js#readme",
   "devDependencies": {
     "ava": "^0.15.2",
+    "babel": "^6.23.0",
+    "babel-cli": "^6.24.1",
     "jszip": "^3.1.3",
+    "nyc": "^11.0.3",
     "proxyquire": "1.7.4"
   },
   "dependencies": {
     "request-promise": "^2.0.1"
+  },
+  "babel": {
+    "presets": [
+      "es2015"
+    ],
+    "plugins": [
+      "transform-runtime"
+    ],
+    "ignore": "test",
+    "env": {
+      "development": {
+        "sourceMaps": "inline"
+      }
+    }
+  },
+  "ava": {
+    "require": [
+      "babel-core/register"
+    ]
   }
 }

--- a/tools/merge-coverage.sh
+++ b/tools/merge-coverage.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+tempDir="coveragetemp"
+mkdir $tempDir
+mkdir $tempDir/unit
+mkdir $tempDir/integration
+
+#Create json coverage items for unit and integration tests
+node ./node_modules/nyc/bin/nyc.js ava test/unit
+mv .nyc_output/* $tempDir/unit
+
+node ./node_modules/nyc/bin/nyc.js ./test/integration/prepIntegrationTests.sh guest
+mv .nyc_output/* $tempDir/integration
+
+#move merged json back and delete temporary folder
+cp -a $tempDir/unit/. .nyc_output
+cp -a $tempDir/integration/. .nyc_output
+rm -rf $tempDir
+
+# generate the HTML report from the merged results
+node ./node_modules/nyc/bin/nyc.js report --reporter=html

--- a/tools/merge-coverage.sh
+++ b/tools/merge-coverage.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+runningEnv="$1"
+
 tempDir="coveragetemp"
 mkdir $tempDir
 mkdir $tempDir/unit
@@ -6,9 +8,11 @@ mkdir $tempDir/integration
 
 #Create json coverage items for unit and integration tests
 node ./node_modules/nyc/bin/nyc.js ava test/unit
+unitstatus="$PIPESTATUS"
 mv .nyc_output/* $tempDir/unit
 
 node ./node_modules/nyc/bin/nyc.js ./test/integration/prepIntegrationTests.sh guest
+integrationstatus="$PIPESTATUS"
 mv .nyc_output/* $tempDir/integration
 
 #move merged json back and delete temporary folder
@@ -17,4 +21,16 @@ cp -a $tempDir/integration/. .nyc_output
 rm -rf $tempDir
 
 # generate the HTML report from the merged results
+if [ "$runningEnv" == "travis" ] ; then
+  npm run coverage
+fi
+
 node ./node_modules/nyc/bin/nyc.js report --reporter=html
+
+
+if [ "$unitstatus" = "0" ] && [ "$integrationstatus" = "0" ] ; then
+    exit 0
+else
+    echo "one or more of either the unit tests or integration tests failed: unit status: $unitstatus; integration status: $integrationstatus;"
+    exit 1
+fi

--- a/tools/travis/build.sh
+++ b/tools/travis/build.sh
@@ -42,5 +42,6 @@ wsk property set --auth "$(cat $WHISKDIR/ansible/files/auth.guest)"
 
 # Test
 cd $ROOTDIR
-npm install
-./test/integration/prepIntegrationTests.sh guest
+npm install --dev
+npm run code-coverage-build
+npm run code-coverage-run travis

--- a/tools/travis/unit.sh
+++ b/tools/travis/unit.sh
@@ -1,8 +1,0 @@
-set -e
-SCRIPTDIR=$(cd $(dirname "$0") && pwd)
-ROOTDIR="$SCRIPTDIR/../.."
-
-cd $ROOTDIR
-npm install
-npm run test
-exit $PIPESTATUS


### PR DESCRIPTION
The current test suite is written in AVA (https://github.com/avajs/ava)
NYC (Istanbul) is the recommended tool for creating code coverage reports. 

There are two commands added that 
1. convert ECMA6-->ECMA5 (requirement for nyc)
2. run the tests/coverage for unit and integration tests, combine their output, and formulate a report view-able in the browser.

gitignore file ignores node8 autogenerated files, some mac finder hidden files, ECMA5 version of library, and nyc output.

README documentation proofed by Josh K.