### PR TITLE
chore: Ignore .idea directory from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ ecma5
 .DS_STORE
 package-lock.json
 coverage.lcov
+.idea


### PR DESCRIPTION
Why do you ignore package.lock.json ?