### PR TITLE
change cli to curl for integration script

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,11 +503,7 @@ If your local environment is using self-signed certificates, you can use the fol
 This will disable SSL/TLS verification for all SSL communication.
 
 Alternatively, you can run the `prepIntegrationTests.sh` script using guest credentials or by specifying specific credentials.  
-Run the script with guest credentials:  
-```
-./test/integration/prepIntegrationTests.sh guest
-```  
-Run the script with specific credentials:  
+Run the script with openwhisk credentials:  
 ```
 ./test/integration/prepIntegrationTests.sh <your key in the form of ABCD:EFGH> <openwhisk instance hostname> <openwhisk namespace> <api gatewaytoken>
 ```  
@@ -524,6 +520,6 @@ To compile down to ECMA5 run the following command:
 1 `npm run code-coverage-build`  
 
 To generate combined reports of both the unit and integration tests, run the following command:  
-2 `npm run code-coverage-run`  
+2 `npm run code-coverage-run <key> <host> <namespace> <token> <options>`  
 
 The report is viewable under `/coverage`. Click **`/coverage/index.html`** to view the full report.  

--- a/tools/merge-coverage.sh
+++ b/tools/merge-coverage.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
-runningEnv="$1"
+key="$1"
+host="$2"
+namespace="$3"
+token="$4"
+runningEnv="$5"
+insecure=""
+
+if [[ "$runningEnv" == *"insecure"* ]] ; then
+  insecure="insecure"
+fi
+
 
 tempDir="coveragetemp"
 mkdir $tempDir
@@ -11,7 +21,7 @@ node ./node_modules/nyc/bin/nyc.js ava test/unit
 unitstatus="$PIPESTATUS"
 mv .nyc_output/* $tempDir/unit
 
-node ./node_modules/nyc/bin/nyc.js ./test/integration/prepIntegrationTests.sh guest
+node ./node_modules/nyc/bin/nyc.js ./test/integration/prepIntegrationTests.sh $key $host $namespace $token $insecure
 integrationstatus="$PIPESTATUS"
 mv .nyc_output/* $tempDir/integration
 
@@ -21,7 +31,7 @@ cp -a $tempDir/integration/. .nyc_output
 rm -rf $tempDir
 
 # generate the HTML report from the merged results
-if [ "$runningEnv" == "travis" ] ; then
+if [[ "$runningEnv" == *"travis"* ]] ; then
   npm run coverage
 fi
 

--- a/tools/travis/build.sh
+++ b/tools/travis/build.sh
@@ -10,7 +10,7 @@ WHISKDIR="$ROOTDIR/../openwhisk"
 # Install OpenWhisk
 cd $WHISKDIR/ansible
 
-ANSIBLE_CMD="ansible-playbook -i environments/local -e docker_image_prefix=openwhisk"
+ANSIBLE_CMD="ansible-playbook -i environments/local -e docker_image_prefix=openwhisk "
 
 $ANSIBLE_CMD setup.yml
 $ANSIBLE_CMD prereq.yml
@@ -19,29 +19,21 @@ $ANSIBLE_CMD initdb.yml
 $ANSIBLE_CMD apigateway.yml
 
 cd $WHISKDIR
-./gradlew :tools:cli:distDocker -PdockerImagePrefix=openwhisk
-
+ ./gradlew  -PdockerImagePrefix=openwhisk
 cd $WHISKDIR/ansible
 
 $ANSIBLE_CMD wipe.yml
-$ANSIBLE_CMD openwhisk.yml
+$ANSIBLE_CMD openwhisk.yml  -e '{"openwhisk_cli":{"installation_mode":"remote","remote":{"name":"OpenWhisk_CLI","dest_name":"OpenWhisk_CLI","location":"https://github.com/apache/incubator-openwhisk-cli/releases/download/latest"}}}'
 $ANSIBLE_CMD postdeploy.yml
 
 cd $WHISKDIR
 cat whisk.properties
 
-# Set Environment
-export OPENWHISK_HOME=$WHISKDIR
-
-# Set up CLI tool used by prereq script
-sudo cp $WHISKDIR/bin/wsk /usr/bin/wsk
-
 edgehost=$(cat $WHISKDIR/whisk.properties | grep edge.host= | sed s/edge\.host=//)
-wsk property set --apihost $edgehost
-wsk property set --auth "$(cat $WHISKDIR/ansible/files/auth.guest)"
+key=$(cat $WHISKDIR/ansible/files/auth.guest)
 
 # Test
 cd $ROOTDIR
 npm install --dev
 npm run code-coverage-build
-npm run code-coverage-run travis
+npm run code-coverage-run $key $edgehost guest true "travis,insecure"


### PR DESCRIPTION
Replace wsk cli usages with calls to the openwhisk api 
  • as a result - does not assume whisk.properties exists - so key, host, namespace, and apig token need to be passed in. No automatic fetching of these credentials.
  • add insecure flag

Functional Ansible commands thanks to Carlos and Vincent.

Build time not reduced - but no longer dependent on cli being built

Accommodations for making work with travis.