### PR TITLE
remove test dependency on resource created before script run

### DIFF
--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -10,39 +10,6 @@ Running the integration tests requires the following environment variables to be
 
 You can retrieve these settings from the `.wskprops` file.
 
-Further, you need to create the following seed artifacts.
+*Note:* If the tests fail, you might need to remove the created artifacts manually.
 
-Action
----
-* Name: hello 
-
-```
-function main() {
-   return {payload: 'Hello world'};
-}
-```
-
-Action
----
-* Name: tests 
-
-```
-function main() {
-   return {payload: 'Hello world'};
-}
-```
-
-Trigger
----
-* Name: sample
-
-
-If you have the `wsk` CLI installed, you may create the required actions and trigger as follows:
-
-    wsk action  create hello action.js
-    wsk action  create tests action.js
-    wsk trigger create sample
-
-where `action.js` contains the `main` function shown above.
-
-*Note:* If the tests fail, the cleanup code does not currently run. You will need to remove the created artifacts manually.
+[Alternatively](https://github.com/apache/incubator-openwhisk-client-js#integration-tests), you can run the `prepIntegrationTests.sh` script using guest credentials or by specifying specific credentials.  


### PR DESCRIPTION
•Remove creation of action `hello`, action `tests`, and trigger `sample` from pre-Integration tests script.
•Add creation of 'hello' and 'tests' to their needed tests. 
•add deletion of 'hello' and 'tests' to their needed tests.
•sample didn't appear to be used.

•Removed integration-test documentation about adding resources prior to script run. 
•Added line linking to integration-test-page-anchor to give information on using script to automate.