### PR TITLE
Add support for action limits and annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,8 @@ The following mandatory parameters are supported:
 The following optional parameters are supported:
 - `namespace` - set custom namespace for endpoint
 - `params` - object containing default parameters for the action (default: `{}`)
+- `annotations` - object containing annotations for the action (default: `{}`)
+- `limits` - object containing limits for the action (default: `{}`)
 - `kind` - runtime environment parameter, ignored when `action` is an object (default: `nodejs:default`)
 - `version` - set semantic version of the action. If parameter is empty when create new action openwisk generate 0.0.1 value when update an action increase the patch version.
 

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -57,6 +57,14 @@ class Actions extends Resources {
       body.version = options.version;
     }
 
+    if (options.limits) {
+      body.limits = options.limits;
+    }
+
+    if (typeof options.annotations === 'object') {
+      body.annotations = Object.keys(options.annotations).map(key => ({ key, value: options.annotations[key] }))
+    }
+
     return body
   }
 }

--- a/test/unit/actions.test.js
+++ b/test/unit/actions.test.js
@@ -328,6 +328,48 @@ test('create a new action with default parameters', t => {
   return actions.create({name: '12345', action, params})
 })
 
+test('create a new action with annotations', t => {
+  t.plan(4)
+  const ns = '_'
+  const client = {}
+  const action = 'function main() { // main function body};'
+  const annotations = {
+    foo: 'bar'
+  }
+  const actions = new Actions(client)
+
+  client.request = (method, path, options) => {
+    t.is(method, 'PUT')
+    t.is(path, `namespaces/${ns}/actions/12345`)
+    t.deepEqual(options.qs, {})
+    t.deepEqual(options.body, {exec: {kind: 'nodejs:default', code: action}, annotations: [
+      { key: 'foo', value: 'bar' }
+    ]})
+  }
+
+  return actions.create({name: '12345', action, annotations})
+})
+
+test('create a new action with limits', t => {
+  t.plan(4)
+  const ns = '_'
+  const client = {}
+  const action = 'function main() { // main function body};'
+  const limits = {
+    timout: 300000
+  }
+  const actions = new Actions(client)
+
+  client.request = (method, path, options) => {
+    t.is(method, 'PUT')
+    t.is(path, `namespaces/${ns}/actions/12345`)
+    t.deepEqual(options.qs, {})
+    t.deepEqual(options.body, {exec: {kind: 'nodejs:default', code: action}, limits: {timeout: 300000}})
+  }
+
+  return actions.create({name: '12345', action, limits})
+})
+
 test('create an action without providing an action body', t => {
   const actions = new Actions()
   t.throws(() => actions.create({name: '12345'}), /Missing mandatory action/)

--- a/test/unit/actions.test.js
+++ b/test/unit/actions.test.js
@@ -356,7 +356,7 @@ test('create a new action with limits', t => {
   const client = {}
   const action = 'function main() { // main function body};'
   const limits = {
-    timout: 300000
+    timeout: 300000
   }
   const actions = new Actions(client)
 


### PR DESCRIPTION
This patch is intended to add support for specifying annotations and limits on action creation or update.