### PR TITLE
Adding support for responsetype parameter during route create.

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,7 +464,8 @@ ow.routes.create({relpath: '...', operation: '...', action: '...'})
 
 *`action` supports normal (actionName) and fully-qualified (/namespace/actionName) formats.*
 
-The following optional parameters are supported to filter the result set:
+The following optional parameters are supported:
+- `responsetype` - content type returned by web action, possible values: `html`, `http`, `json`, `text` and `svg` (default: `json`).
 - `basepath` - base URI path for endpoints (default: `/`)
 
 ## Debugging

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -10,9 +10,7 @@ const CREATE_PARAMS = ['relpath', 'operation', 'action']
 
 class Routes extends BaseOperation {
   routeMgmtApiPath (path) {
-    return this.has_access_token() ?
-      `web/whisk.system/apimgmt/${path}.http` :
-      `experimental/web/whisk.system/routemgmt/${path}.json`
+    return `web/whisk.system/apimgmt/${path}.http`
   }
 
   list (options) {
@@ -76,7 +74,7 @@ class Routes extends BaseOperation {
     return {
       name: id,
       namespace: namespace,
-      backendMethod: this.action_url_method(),
+      backendMethod: `GET`,
       backendUrl: this.action_url_path(id, namespace),
       authkey: this.client.options.api_key
     }
@@ -86,15 +84,7 @@ class Routes extends BaseOperation {
     return params.basepath || '/'
   }
 
-  action_url_method () {
-    return this.has_access_token() ? 'GET' : 'POST'
-  }
-
   action_url_path (id, namespace) {
-    if (!this.has_access_token()) {
-      return this.client.path_url(`namespaces/${namespace}/actions/${id}`)
-    }
-
     // web action path must contain package identifier. uses default for
     // non-explicit package.
     if (!id.includes('/')) {

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -48,7 +48,7 @@ class Routes extends BaseOperation {
     }
 
     const body = this.route_swagger_definition(options)
-    const qs = this.qs(options, [])
+    const qs = this.qs(options, ['responsetype'])
     return this.client.request('POST', this.routeMgmtApiPath('createApi'), { body, qs })
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openwhisk",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "description": "JavaScript client library for the OpenWhisk platform",
   "main": "lib/main.js",
   "typings": "lib/main.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openwhisk",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "description": "JavaScript client library for the OpenWhisk platform",
   "main": "lib/main.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openwhisk",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "JavaScript client library for the OpenWhisk platform",
   "main": "lib/main.js",
   "engines": {

--- a/test/unit/routes.test.js
+++ b/test/unit/routes.test.js
@@ -6,20 +6,6 @@
 const test = require('ava')
 const Routes = require('../../lib/routes')
 
-test('should return experimental api path without api token', t => {
-  const client = { options: {} }
-  const routes = new Routes(client)
-  t.is(routes.routeMgmtApiPath('a'), 'experimental/web/whisk.system/routemgmt/a.json')
-})
-
-test('should return experimental api path with api token', t => {
-  const client = { options: {
-    apigw_token: true
-  }}
-  const routes = new Routes(client)
-  t.is(routes.routeMgmtApiPath('a'), 'web/whisk.system/apimgmt/a.http')
-})
-
 test('should list all routes', t => {
   t.plan(2)
   const client = { options: {} }
@@ -134,8 +120,8 @@ test('should create a route', t => {
       action: {
         name: 'helloAction',
         namespace: '_',
-        backendMethod: 'POST',
-        backendUrl: 'https://openwhisk.ng.bluemix.net/api/v1/namespaces/_/actions/helloAction',
+        backendMethod: 'GET',
+        backendUrl: 'https://openwhisk.ng.bluemix.net/api/v1/web/_/default/helloAction.http',
         authkey: api_key }
     }
   }
@@ -273,8 +259,8 @@ test('should create a route using global ns', t => {
       action: {
         name: 'helloAction',
         namespace: 'global_ns',
-        backendMethod: 'POST',
-        backendUrl: 'https://openwhisk.ng.bluemix.net/api/v1/namespaces/global_ns/actions/helloAction',
+        backendMethod: 'GET',
+        backendUrl: 'https://openwhisk.ng.bluemix.net/api/v1/web/global_ns/default/helloAction.http',
         authkey: api_key }
     }
   }
@@ -307,8 +293,8 @@ test('should create a route using basepath', t => {
       action: {
         name: 'helloAction',
         namespace: '_',
-        backendMethod: 'POST',
-        backendUrl: 'https://openwhisk.ng.bluemix.net/api/v1/namespaces/_/actions/helloAction',
+        backendMethod: 'GET',
+        backendUrl: 'https://openwhisk.ng.bluemix.net/api/v1/web/_/default/helloAction.http',
         authkey: api_key }
     }
   }
@@ -341,8 +327,8 @@ test('should create a route using fully-qualified action name', t => {
       action: {
         name: 'foo/helloAction',
         namespace: 'test',
-        backendMethod: 'POST',
-        backendUrl: 'https://openwhisk.ng.bluemix.net/api/v1/namespaces/test/actions/foo/helloAction',
+        backendMethod: 'GET',
+        backendUrl: 'https://openwhisk.ng.bluemix.net/api/v1/web/test/foo/helloAction.http',
         authkey: api_key }
     }
   }
@@ -375,8 +361,8 @@ test('should create a route using action name with ns', t => {
       action: {
         name: 'helloAction',
         namespace: 'test',
-        backendMethod: 'POST',
-        backendUrl: 'https://openwhisk.ng.bluemix.net/api/v1/namespaces/test/actions/helloAction',
+        backendMethod: 'GET',
+        backendUrl: 'https://openwhisk.ng.bluemix.net/api/v1/web/test/default/helloAction.http',
         authkey: api_key }
     }
   }
@@ -409,8 +395,8 @@ test('should create a route using action name with ns overriding defaults', t =>
       action: {
         name: 'helloAction',
         namespace: 'test',
-        backendMethod: 'POST',
-        backendUrl: 'https://openwhisk.ng.bluemix.net/api/v1/namespaces/test/actions/helloAction',
+        backendMethod: 'GET',
+        backendUrl: 'https://openwhisk.ng.bluemix.net/api/v1/web/test/default/helloAction.http',
         authkey: api_key }
     }
   }

--- a/test/unit/routes.test.js
+++ b/test/unit/routes.test.js
@@ -171,6 +171,41 @@ test('should create a route with apigw_token', t => {
   return routes.create({relpath: '/hello', operation: 'GET', action: 'helloAction'})
 })
 
+test('should create a route with response type', t => {
+  t.plan(4)
+  const path_url = path => `https://openwhisk.ng.bluemix.net/api/v1/${path}`
+  const api_key = 'username:password'
+  const client_options = { api_key }
+  const client = { path_url, options: client_options }
+  const options = {force: true, basepath: '/hello', relpath: '/bar/1', operation: 'GET'}
+
+  const body = {
+    apidoc: {
+      namespace: '_',
+      gatewayBasePath: '/',
+      gatewayPath: '/hello',
+      gatewayMethod: 'GET',
+      id: 'API:_:/',
+      action: {
+        name: 'helloAction',
+        namespace: '_',
+        backendMethod: 'GET',
+        backendUrl: 'https://openwhisk.ng.bluemix.net/api/v1/web/_/default/helloAction.http',
+        authkey: api_key }
+    }
+  }
+
+  client.request = (method, path, _options) => {
+    t.is(method, 'POST')
+    t.is(path, routes.routeMgmtApiPath('createApi'))
+    t.deepEqual(_options.body, body)
+    t.deepEqual(_options.qs, { responsetype: 'http' })
+  }
+
+  const routes = new Routes(client)
+  return routes.create({relpath: '/hello', operation: 'GET', action: 'helloAction', responsetype: 'http'})
+})
+
 test('should create a route with apigw_token and action with package', t => {
   t.plan(4)
   const path_url = path => `https://openwhisk.ng.bluemix.net/api/v1/${path}`


### PR DESCRIPTION
API GW feature for controlling response type. Used to enable support in Serverless Framework. https://github.com/serverless/serverless-openwhisk/issues/80