### PR TITLE
switch from request-promise to needle

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -5,9 +5,38 @@
 
 const messages = require('./messages')
 const OpenWhiskError = require('./openwhisk_error')
-const rp = require('request-promise')
+const needle = require('needle')
 const url = require('url')
 const http = require('http')
+
+const rp = opts => {
+    opts.json = true
+    if (opts.qs) {
+	// needle isn't as fancy as request, here. we need to turn qs into a query string
+	let first = true
+	for (let key in opts.qs) {
+	    const str = `${encodeURIComponent(key)}=${encodeURIComponent(opts.qs[key])}`
+	    if (first) {
+		opts.url += `?${str}`
+		first = false
+	    } else {
+		opts.url += `&${str}`
+	    }
+	}
+    }
+    return needle(opts.method.toLowerCase(),
+		  opts.url,
+		  opts.body || opts.params,
+		  opts)
+    .then(({body}) => {
+	    if (typeof body === 'string' && body.length === 0) {
+		// needle doesn't handle empty arrays
+		return []
+	    } else {
+		return body
+	    }
+	})
+}
 
 class Client {
   constructor (options) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -9,35 +9,47 @@ const needle = require('needle')
 const url = require('url')
 const http = require('http')
 
+/**
+ * This implements a request-promise-like facade over the needle
+ * library. There are two gaps between needle and rp that need to be
+ * bridged: 1) convert `qs` into a query string; and 2) convert
+ * needle's non-excepting >=400 statusCode responses into exceptions
+ *
+ */
 const rp = opts => {
-    opts.json = true
-
     if (opts.qs) {
-	// needle isn't as fancy as request, here. we need to turn qs into a query string
+        // we turn the qs struct into a query string over the url
 	let first = true
-	for (let key in opts.qs) {
-	    const str = `${encodeURIComponent(key)}=${encodeURIComponent(opts.qs[key])}`
-	    if (first) {
-		opts.url += `?${str}`
-		first = false
-	    } else {
+        for (let key in opts.qs) {
+            const str = `${encodeURIComponent(key)}=${encodeURIComponent(opts.qs[key])}`
+            if (first) {
+                opts.url += `?${str}`
+                first = false
+            } else {
 		opts.url += `&${str}`
-	    }
-	}
+            }
+        }
     }
 
+    // it appears that certain call paths from our code do not set the
+    // opts.json field to true; rp is apparently more resilient to
+    // this situation than needle
+    opts.json = true
+
     return needle(opts.method.toLowerCase(), // needle takes e.g. 'put' not 'PUT'
-		  opts.url,
-		  opts.body || opts.params,
-		  opts)
-    .then(resp => {
+                  opts.url,
+                  opts.body || opts.params,
+                  opts)
+        .then(resp => {
             if (resp.statusCode >= 400) {
+                // we turn >=400 statusCode responses into exceptions
                 const error = new Error(resp.body.error || resp.statusMessage)
-                error.statusCode = resp.statusCode
-                error.options = opts
-                error.error = resp.body
+                error.statusCode = resp.statusCode   // the http status code
+                error.options = opts                 // the code below requires access to the input opts
+                error.error = resp.body              // the error body
                 throw error
             } else {
+                // otherwise, the response body is the expected return value
                 return resp.body
             }
         })

--- a/lib/client.js
+++ b/lib/client.js
@@ -30,7 +30,17 @@ const rp = opts => {
 		  opts.url,
 		  opts.body || opts.params,
 		  opts)
-    .then(({body}) => body) // extract the body field
+    .then(resp => {
+            if (resp.statusCode >= 400) {
+                const error = new Error(resp.body.error || resp.statusMessage)
+                error.statusCode = resp.statusCode
+                error.options = opts
+                error.error = resp.body
+                throw error
+            } else {
+                return resp.body
+            }
+        })
 }
 
 class Client {

--- a/lib/client.js
+++ b/lib/client.js
@@ -11,6 +11,7 @@ const http = require('http')
 
 const rp = opts => {
     opts.json = true
+
     if (opts.qs) {
 	// needle isn't as fancy as request, here. we need to turn qs into a query string
 	let first = true
@@ -24,18 +25,12 @@ const rp = opts => {
 	    }
 	}
     }
-    return needle(opts.method.toLowerCase(),
+
+    return needle(opts.method.toLowerCase(), // needle takes e.g. 'put' not 'PUT'
 		  opts.url,
 		  opts.body || opts.params,
 		  opts)
-    .then(({body}) => {
-	    if (typeof body === 'string' && body.length === 0) {
-		// needle doesn't handle empty arrays
-		return []
-	    } else {
-		return body
-	    }
-	})
+    .then(({body}) => body) // extract the body field
 }
 
 class Client {

--- a/lib/client.js
+++ b/lib/client.js
@@ -19,14 +19,14 @@ const http = require('http')
 const rp = opts => {
     if (opts.qs) {
         // we turn the qs struct into a query string over the url
-	let first = true
+        let first = true
         for (let key in opts.qs) {
             const str = `${encodeURIComponent(key)}=${encodeURIComponent(opts.qs[key])}`
             if (first) {
                 opts.url += `?${str}`
                 first = false
             } else {
-		opts.url += `&${str}`
+                opts.url += `&${str}`
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "proxyquire": "1.7.4"
   },
   "dependencies": {
-    "request-promise": "^2.0.1",
+    "needle": "^2.0.1",
     "@types/node": "^8.0.26",
     "@types/swagger-schema-official": "^2.0.6"
   },

--- a/test/integration/actions.test.js
+++ b/test/integration/actions.test.js
@@ -50,6 +50,29 @@ test('list all actions using options namespace', t => {
   })
 })
 
+test('get a non-existing action, expecting 404', async t => {
+  const actions = new Actions(new Client(options))
+  await actions.get({name: 'glorfindel'}).catch(err => {
+      t.is(err.statusCode, 404)
+  })
+})
+
+test('delete a non-existing action, expecting 404', async t => {
+  const actions = new Actions(new Client(options))
+  await actions.delete({name: 'glorfindel'}).catch(err => {
+      t.is(err.statusCode, 404)
+  })
+})
+
+test('create with an existing action, expecting 409', async t => {
+  const actions = new Actions(new Client(options))
+    await actions.create({name: 'glorfindel2', action: 'x=>x'})
+        .then(actions.create({name: 'glorfindel2', action: 'x=>x'}))
+        .catch(err => {
+            t.is(err.statusCode, 409)
+        })
+})
+
 test('create, get and delete an action', t => {
   const errors = err => {
     console.log(err)

--- a/test/integration/actions.test.js
+++ b/test/integration/actions.test.js
@@ -67,7 +67,7 @@ test('delete a non-existing action, expecting 404', async t => {
 test('create with an existing action, expecting 409', async t => {
   const actions = new Actions(new Client(options))
     await actions.create({name: 'glorfindel2', action: 'x=>x'})
-        .then(actions.create({name: 'glorfindel2', action: 'x=>x'}))
+        .then(() => actions.create({name: 'glorfindel2', action: 'x=>x'}))
         .catch(err => {
             t.is(err.statusCode, 409)
         })

--- a/test/integration/packages.test.js
+++ b/test/integration/packages.test.js
@@ -49,6 +49,13 @@ test('list all packages using options namespace', t => {
   })
 })
 
+test('get a non-existing package, expecting 404', async t => {
+  const packages = new Packages(new Client(options))
+  await packages.get({name: 'glorfindel'}).catch(err => {
+      t.is(err.statusCode, 404)
+  })
+})
+
 test('create, get and delete an package', t => {
   const errors = err => {
     console.log(err)

--- a/test/integration/rules.test.js
+++ b/test/integration/rules.test.js
@@ -51,6 +51,13 @@ test('list all rules using options namespace', t => {
   })
 })
 
+test('get a non-existing rule, expecting 404', async t => {
+  const rules = new Rules(new Client(options))
+  await rules.get({name: 'glorfindel'}).catch(err => {
+      t.is(err.statusCode, 404)
+  })
+})
+
 // Running update tests conconcurrently leads to resource conflict errors.
 test.serial('create, get and delete a rule', t => {
   const errors = err => {

--- a/test/integration/triggers.test.js
+++ b/test/integration/triggers.test.js
@@ -49,6 +49,13 @@ test('list all triggers using options namespace', t => {
   })
 })
 
+test('get a non-existing trigger, expecting 404', async t => {
+  const triggers = new Triggers(new Client(options))
+  await triggers.get({name: 'glorfindel'}).catch(err => {
+      t.is(err.statusCode, 404)
+  })
+})
+
 test('create, get and delete an trigger', t => {
   const errors = err => {
     console.log(err)


### PR DESCRIPTION
Switch from request-promise to needle, for an initialization performance boost. Fixes #77 
Also adds test coverage for 404 and 409 cases. Fixes #79