### PR TITLE
Support retrieving status and configuration of feed triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ ow.triggers.get({name: '...'})
 ow.rules.get({name: '...'})
 ow.namespaces.get({name: '...'})
 ow.packages.get({name: '...'})
+ow.feeds.get({name: '...'})
 ```
 
 The following optional parameters are supported:

--- a/lib/feeds.js
+++ b/lib/feeds.js
@@ -21,6 +21,10 @@ class Feeds {
     return this.feed('CREATE', options)
   }
 
+  get (options) {
+    return this.feed('READ', options)
+  }
+
   feed (event, options) {
     if (!this.feed_name(options)) {
       throw new Error(messages.MISSING_FEED_NAME_ERROR)

--- a/test/integration/feeds.test.js
+++ b/test/integration/feeds.test.js
@@ -38,11 +38,14 @@ tempTest('create and delete a feed', t => {
   }
   return triggers.create({triggerName: 'sample_feed_trigger'}).then(() => feeds.create(feed_params)).then(result => {
     t.is(result.response.success, true)
-    return feeds.delete(feed_params).then(feed_result => {
-      t.is(feed_result.response.success, true)
-      return triggers.delete({triggerName: 'sample_feed_trigger'}).then(() => {
-        t.pass()
-      })
+    return feeds.get(feed_params).then(get_result => {
+      t.is(get_result.response.success, true)
+      return feeds.delete(feed_params).then(feed_result => {
+        t.is(feed_result.response.success, true)
+        return triggers.delete({triggerName: 'sample_feed_trigger'}).then(() => {
+          t.pass()
+        })
+      }).catch(errors)
     }).catch(errors)
   }).catch(errors)
 })

--- a/test/unit/feeds.test.js
+++ b/test/unit/feeds.test.js
@@ -206,6 +206,28 @@ test('should be able to create feed using feedName with params', t => {
   return feeds.create({feedName: feed_name, trigger: trigger_name, params})
 })
 
+test('should be able to get feed', t => {
+  const feed_name = 'feed_name'
+  const api_key = 'username:password'
+  const trigger_name = '/trigger_ns/trigger_name'
+  const client = {}
+  client.options = { api_key }
+
+  const ns = '_'
+  const feeds = new Feeds(client)
+
+  client.request = (method, path, options) => {
+    t.is(method, 'POST')
+    t.is(path, `namespaces/${ns}/actions/${feed_name}`)
+    t.deepEqual(options.qs, {blocking: true})
+    t.deepEqual(options.body, {authKey: client.options.api_key, lifecycleEvent: 'READ', triggerName: `${trigger_name}`})
+  }
+
+  t.plan(4)
+
+  return feeds.get({name: feed_name, trigger: trigger_name})
+})
+
 test('should throw errors without trigger parameter ', t => {
   const ns = '_'
   const client = { options: {} }


### PR DESCRIPTION
This PR is to add support for retrieving the status and configuration of a feed trigger

Support has been implemented in the feed providers with the following:

apache/incubator-openwhisk-package-kafka#217 <-- Merged
apache/incubator-openwhisk-package-cloudant#137 <-- Merged
apache/incubator-openwhisk-package-alarms#101 <-- Merged