### PR TITLE
require at least needle 2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "proxyquire": "1.7.4"
   },
   "dependencies": {
-    "needle": "^2.0.1",
+    "needle": "^2.1.0",
     "@types/node": "^8.0.26",
     "@types/swagger-schema-official": "^2.0.6"
   },


### PR DESCRIPTION
needle 2.1.0 has a fix for the socket hangup issues resulting from needle's erroneous implementation of open timeout

Fixes #89 
