### PR TITLE
Allow string argument for action get API

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,12 @@ ow.feeds.get({name: '...', trigger: '...'})
 The following optional parameters are supported for all resource retrievals:
 - `namespace` - set custom namespace for endpoint
 
+This method also supports passing the `name` property directly without wrapping within an object.
+```javascript
+const name = "actionName"
+ow.actions.get(name)
+```
+
 Optional parameters for action resource retrievals are shown below:
 - `code` - set to `true` or `false` depending on whether action code should be included or excluded respectively
 

--- a/README.md
+++ b/README.md
@@ -252,14 +252,14 @@ ow.feeds.get({name: '...', trigger: '...'})
 The following optional parameters are supported for all resource retrievals:
 - `namespace` - set custom namespace for endpoint
 
+Optional parameters for action resource retrievals are shown below:
+- `code` - set to `true` or `false` depending on whether action code should be included or excluded respectively
+
 This method also supports passing the `name` property directly without wrapping within an object.
 ```javascript
 const name = "actionName"
 ow.actions.get(name)
 ```
-
-Optional parameters for action resource retrievals are shown below:
-- `code` - set to `true` or `false` depending on whether action code should be included or excluded respectively
 
 If you pass in an array for the first parameter, the `get` call will be executed for each array item. The function returns a Promise which resolves with the results when all operations have finished.
 

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -22,7 +22,7 @@ class Actions extends Resources {
   }
 
   get (options) {
-    options = options || {}
+    options = this.parse_options(options)
     options.qs = this.qs(options, ['code'])
 
     return this.operation_with_id('GET', options)

--- a/test/unit/actions.test.js
+++ b/test/unit/actions.test.js
@@ -79,7 +79,7 @@ test('should retrieve action from string identifier', t => {
     t.is(path, `namespaces/${ns}/actions/12345`)
   }
 
-  return actions.get({name: '12345'})
+  return actions.get('12345')
 })
 
 test('should delete action from identifier', t => {


### PR DESCRIPTION
Restores original action get API that allows for an action name to be passed to the get method as a string.