### PR TITLE
add User-Agent to request header

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,20 @@ Client constructor will read values for the `apihost`, `namespace`, `api_key`, `
 - *__OW_APIGW_TOKEN*
 - *__OW_APIGW_SPACE_SUID*
 
+### User-Agent
 
+A User-Agent header may be specified to be passed along with all calls
+to OpenWhisk. This can be helpful, if you wish to discriminate client
+traffic to your OpenWhisk backend. By default, the header will have
+the value `openwhisk-client-js`. You may override this by passing
+along a `'User-Agent'` field in the options structure of any API
+calls; note that this is *not* a constructor argument, but rather an
+option to the API calls themselves. For example, one might specify a
+`myClient` user agent to an action invocation as follows:
+
+```javascript
+ow.actions.invoke({ 'User-Agent': 'myClient', name, params })
+```
 
 ## Examples
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -124,6 +124,7 @@ class Client {
       url: this.pathUrl(path),
       rejectUnauthorized: !this.options.ignoreCerts,
       headers: {
+        'User-Agent': (options && options['User-Agent']) || 'openwhisk-client-js',
         Authorization: this.authHeader()
       }
     }, options)

--- a/test/unit/actions.test.js
+++ b/test/unit/actions.test.js
@@ -429,3 +429,18 @@ test('create a new action with version parameter', t => {
 
   return actions.create({name: '12345', action, version})
 })
+
+test('should pass through requested User-Agent header', t => {
+  t.plan(1)
+  const userAgent = 'userAgentShouldPassThroughPlease'
+  const client = {}
+  const actions = new Actions(client)
+  const action = 'function main() { // main function body};'
+  const version = '1.0.0'
+
+  client.request = (method, path, options) => {
+    t.is(options['User-Agent'], userAgent)
+  }
+
+  return actions.create({name: '12345', action, version, 'User-Agent': userAgent})
+})


### PR DESCRIPTION
This imposes a default User-Agent, if the client did not specify one. We could change this to leave it blank if not specified; but my opinion right now would be to always specify something.

Fixes #117