### PR TITLE
Test case and fix for #121

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -50,6 +50,11 @@ class Actions extends Resources {
     }
     const body = {exec: {kind: options.kind || 'nodejs:default', code: options.action}}
 
+    // allow options to override the derived exec object
+    if (options.exec) {
+      body.exec = Object.assign(body.exec, options.exec)
+    }
+
     if (options.action instanceof Buffer) {
       body.exec.code = options.action.toString('base64')
     } else if (typeof options.action === 'object') {

--- a/test/unit/actions.test.js
+++ b/test/unit/actions.test.js
@@ -474,5 +474,22 @@ test('should pass through exec.image parameter (for all kinds)', t => {
     t.is(options.body.exec.image, image)
   }
 
-  return actions.create({name: '12345', action, version, exec})
+  return actions.create({name: '12345', action, version, exec, kind: 'xyz'})
+})
+
+
+test('should not reset kind parameter when passing through exec.image parameter', t => {
+  t.plan(1)
+  const image = 'openwhisk/action-nodejs-v8:latest'
+  const exec = { image: image }
+  const client = {}
+  const actions = new Actions(client)
+  const action = 'function main() { // main function body};'
+  const version = '1.0.0'
+
+  client.request = (method, path, options) => {
+    t.is(options.body.exec.kind, 'xyz')
+  }
+
+  return actions.create({name: '12345', action, version, exec, kind: 'xyz'})
 })

--- a/test/unit/actions.test.js
+++ b/test/unit/actions.test.js
@@ -455,8 +455,7 @@ test('should pass through exec.image parameter', t => {
   const version = '1.0.0'
 
   client.request = (method, path, options) => {
-    t.is(options.exec.image, image)
-    t.is(options.kind, 'blackbox')
+    t.is(options.body.exec.image, image)
   }
 
   return actions.create({name: '12345', action, version, exec, kind: 'blackbox'})

--- a/test/unit/actions.test.js
+++ b/test/unit/actions.test.js
@@ -460,3 +460,19 @@ test('should pass through exec.image parameter', t => {
 
   return actions.create({name: '12345', action, version, exec, kind: 'blackbox'})
 })
+
+test('should pass through exec.image parameter (for all kinds)', t => {
+  t.plan(1)
+  const image = 'openwhisk/action-nodejs-v8:latest'
+  const exec = { image: image }
+  const client = {}
+  const actions = new Actions(client)
+  const action = 'function main() { // main function body};'
+  const version = '1.0.0'
+
+  client.request = (method, path, options) => {
+    t.is(options.body.exec.image, image)
+  }
+
+  return actions.create({name: '12345', action, version, exec})
+})

--- a/test/unit/actions.test.js
+++ b/test/unit/actions.test.js
@@ -444,3 +444,20 @@ test('should pass through requested User-Agent header', t => {
 
   return actions.create({name: '12345', action, version, 'User-Agent': userAgent})
 })
+
+test('should pass through exec.image parameter', t => {
+  t.plan(1)
+  const image = 'openwhisk/action-nodejs-v8:latest'
+  const exec = { image: image }
+  const client = {}
+  const actions = new Actions(client)
+  const action = 'function main() { // main function body};'
+  const version = '1.0.0'
+
+  client.request = (method, path, options) => {
+    t.is(options.exec.image, image)
+    t.is(options.kind, 'blackbox')
+  }
+
+  return actions.create({name: '12345', action, version, exec, kind: 'blackbox'})
+})

--- a/test/unit/actions.test.js
+++ b/test/unit/actions.test.js
@@ -477,7 +477,6 @@ test('should pass through exec.image parameter (for all kinds)', t => {
   return actions.create({name: '12345', action, version, exec, kind: 'xyz'})
 })
 
-
 test('should not reset kind parameter when passing through exec.image parameter', t => {
   t.plan(1)
   const image = 'openwhisk/action-nodejs-v8:latest'


### PR DESCRIPTION
This is a simple test case and fix for #121 

In my solution, I've taken the simplest possible approach: instead of inventing a new `image` or `docker` parameter that goes into `options` and would need special treatment, I'm simply checking for the presence of `options.exec` and use what's provided there.

This comes at the risk of having people override the values we infer for our own `exec` object, but I'd assume people using the `exec` parameter know what they are doing.