### PR TITLE
pass-through user-agent in namespace.list and .get, and activation.get

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,14 @@ option to the API calls themselves. For example, one might specify a
 ow.actions.invoke({ 'User-Agent': 'myClient', name, params })
 ```
 
+In some cases, you may need to have *no* User-Agent header. To
+override the default header behavior, you may pass `noUserAgent: true`
+in your options structure, e.g.
+
+```javascript
+ow.actions.invoke({ noUserAgent: true, name, params })
+```
+
 ## Examples
 
 ### invoke action, blocking for result

--- a/lib/activations.js
+++ b/lib/activations.js
@@ -30,7 +30,7 @@ class Activations extends BaseOperation {
     const id = this.getActivation(options)
     const namespace = this.namespace(options)
     const urlPath = `namespaces/${namespace}/activations/${id}` + (path ? `/${path}` : '')
-    return this.client.request('GET', urlPath)
+    return this.client.request('GET', urlPath, options)
   }
 
   getActivation (options) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -67,6 +67,7 @@ class Client {
    * @param {string} [options.apigw_token]
    * @param {string} [options.apigw_space_guid]
    * @param {Function} [options.auth_handler]
+   * @param {boolean} [options.noUserAgent]
    */
   constructor (options) {
     this.options = this.parseOptions(options || {})
@@ -98,7 +99,7 @@ class Client {
       throw new Error(`${messages.INVALID_OPTIONS_ERROR} Missing either api or apihost parameters.`)
     }
 
-    return {apiKey: apiKey, api, ignoreCerts: ignoreCerts, namespace: options.namespace, apigwToken: apigwToken, apigwSpaceGuid: apigwSpaceGuid, authHandler: options.auth_handler}
+    return {apiKey: apiKey, api, ignoreCerts: ignoreCerts, namespace: options.namespace, apigwToken: apigwToken, apigwSpaceGuid: apigwSpaceGuid, authHandler: options.auth_handler, noUserAgent: options.noUserAgent}
   }
 
   urlFromApihost (apihost) {
@@ -120,7 +121,7 @@ class Client {
 
   params (method, path, options) {
     return this.authHeader().then(header => {
-      return Object.assign({
+      const parms = Object.assign({
         json: true,
         method: method,
         url: this.pathUrl(path),
@@ -130,6 +131,13 @@ class Client {
           Authorization: header
         }
       }, options)
+
+      if (this.options.noUserAgent || parms.noUserAgent) {
+        // caller asked for no user agent?
+        parms.headers['User-Agent'] = undefined
+      }
+
+      return parms
     })
   }
 

--- a/lib/namespaces.js
+++ b/lib/namespaces.js
@@ -6,15 +6,15 @@
 const BaseOperation = require('./base_operation')
 
 class Namespaces extends BaseOperation {
-  list () {
-    return this.client.request('GET', 'namespaces')
+  list (options) {
+    return this.client.request('GET', 'namespaces', options)
   }
 
-  get () {
-    let actions = this.client.request('GET', 'namespaces/_/actions')
-    let packages = this.client.request('GET', 'namespaces/_/packages')
-    let triggers = this.client.request('GET', 'namespaces/_/triggers')
-    let rules = this.client.request('GET', 'namespaces/_/rules')
+  get (options) {
+    let actions = this.client.request('GET', 'namespaces/_/actions', options)
+    let packages = this.client.request('GET', 'namespaces/_/packages', options)
+    let triggers = this.client.request('GET', 'namespaces/_/triggers', options)
+    let rules = this.client.request('GET', 'namespaces/_/rules', options)
     return Promise
       .all([actions, packages, triggers, rules])
       .then(([actions, packages, triggers, rules]) => ({actions, packages, triggers, rules}))

--- a/test/unit/activations.test.js
+++ b/test/unit/activations.test.js
@@ -72,6 +72,23 @@ test('should retrieve an activation', t => {
   return activations.get({name: activationId})
 })
 
+test('should retrieve an activation passing through user-agent header', t => {
+  t.plan(3)
+  const ns = '_'
+  const client = {}
+  const activations = new Activations(client)
+  const activationId = 'random_id'
+  const userAgent = 'userAgentShouldPassThroughPlease'
+
+  client.request = (method, path, options) => {
+    t.is(method, 'GET')
+    t.is(path, `namespaces/${ns}/activations/${activationId}`)
+    t.is(options['User-Agent'], userAgent)
+  }
+
+  return activations.get({name: activationId, 'User-Agent': userAgent})
+})
+
 test('should retrieve an activation using alt id parameter', t => {
   t.plan(2)
   const ns = '_'

--- a/test/unit/namespaces.test.js
+++ b/test/unit/namespaces.test.js
@@ -4,6 +4,7 @@
 'use strict'
 
 const test = require('ava')
+const Client = require('../../lib/client')
 const Namespaces = require('../../lib/namespaces')
 
 test('should list all namespaces', t => {
@@ -16,6 +17,80 @@ test('should list all namespaces', t => {
 
   const namespaces = new Namespaces(client)
   return namespaces.list()
+})
+
+test('should list all namespaces, passing through user-agent header', t => {
+  t.plan(3)
+  const client = {}
+  const userAgent = 'userAgentShouldPassThroughPlease'
+  client.request = (method, path, options) => {
+    t.is(method, 'GET')
+    t.is(path, `namespaces`)
+    t.is(options['User-Agent'], userAgent)
+  }
+
+  const namespaces = new Namespaces(client)
+  return namespaces.list({'User-Agent': userAgent})
+})
+
+test('should list all namespaces, NOT passing through user-agent header (variant 1)', t => {
+  t.plan(3)
+  const client = {}
+  const userAgent = 'userAgentShouldPassThroughPlease'
+  client.request = async (method, path, options) => {
+    t.is(method, 'GET')
+    t.is(path, `namespaces`)
+
+    const parms = await new Client({api: 'aaa', api_key: 'aaa'}).params(method, path, options)
+    t.is(parms.headers['User-Agent'], undefined)
+  }
+
+  const namespaces = new Namespaces(client)
+  return namespaces.list({'User-Agent': userAgent, noUserAgent: true})
+})
+
+test('should list all namespaces, NOT passing through user-agent header (variant 2)', t => {
+  t.plan(3)
+  const client = {}
+  const userAgent = 'userAgentShouldPassThroughPlease'
+  client.request = async (method, path, options) => {
+    t.is(method, 'GET')
+    t.is(path, `namespaces`)
+
+    const parms = await new Client({api: 'aaa', api_key: 'aaa', noUserAgent: true}).params(method, path, options)
+    t.is(parms.headers['User-Agent'], undefined)
+  }
+
+  const namespaces = new Namespaces(client)
+  return namespaces.list({'User-Agent': userAgent})
+})
+
+test('should list all namespaces, NOT passing through user-agent header (variant 3)', t => {
+  t.plan(3)
+  const client = {}
+  client.request = async (method, path, options) => {
+    t.is(method, 'GET')
+    t.is(path, `namespaces`)
+
+    const parms = await new Client({api: 'aaa', api_key: 'aaa', noUserAgent: true}).params(method, path, options)
+    t.is(parms.headers['User-Agent'], undefined)
+  }
+
+  const namespaces = new Namespaces(client)
+  return namespaces.list({})
+})
+
+test('should list all namespaces, NOT passing through user-agent header (variant 4)', t => {
+  t.plan(3)
+  const client = {}
+  client.request = (method, path, options) => {
+    t.is(method, 'GET')
+    t.is(path, `namespaces`)
+    t.is(options['User-Agent'], undefined)
+  }
+
+  const namespaces = new Namespaces(client)
+  return namespaces.list({noUserAgent: true})
 })
 
 test('should retrieve namespace entities', t => {
@@ -31,4 +106,21 @@ test('should retrieve namespace entities', t => {
 
   const namespaces = new Namespaces(client)
   return namespaces.get()
+})
+
+test('should retrieve namespace entities, passing through user-agent header', t => {
+  t.plan(20)
+  const client = {}
+  const userAgent = 'userAgentShouldPassThroughPlease'
+  client.request = (method, path, options) => {
+    t.is(method, 'GET')
+    let parts = path.split('/')
+    t.is(parts[0], 'namespaces')
+    t.is(parts[1], '_')
+    t.is(['actions', 'triggers', 'rules', 'packages'].indexOf(parts[2]) > -1, true)
+    t.is(options['User-Agent'], userAgent)
+  }
+
+  const namespaces = new Namespaces(client)
+  return namespaces.get({'User-Agent': userAgent})
 })


### PR DESCRIPTION
also add a `noUserAgent` option, to prevent assigning a default user-agent

plus tests

Fixes #135