### PR TITLE
Openwhisk proxy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,5 +23,3 @@ deploy:
   on:
     tags: true
     repo: apache/incubator-openwhisk-client-js
- 
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,8 @@ deploy:
     secure: DBM6VScujsLbzNKOsZHX6/u+S7NKFbuzU/iKt20HmobUUDrCEOhL9aY+ojAw3mFktaM6M7U6fq8uazvXtqcsIy5j3prAIelZyJep1Tl1zkLptdphoa8DkDP5ErbjwN9LMZBs74PRKZDDsKJfgMDYHMw05gYsnDXhZ49V+2JCuJ5e3jidVAeXsdcF3pkxc5+YLk4IQ/ryk6bSG2VTA0U+Opcck7Z2S6JrVwvbJsLJcknsYXMMq4fttRIAXcG+yw8F8vndN9Ge50EJLsazHzyIxCPZhBNwTU9T7vwCB3XtepP+ghbb0CVI6DvfXPwPzw1iQDSOkKk8aFt77jdGV4HEdFitpukbzhmKEF6zd0SDwLkvPwafZhNNAchhv/VganFFj/ebPFtXMxI1SgvPGTsDIj6s2D6JGTgZN2BSzKRfUf0s05Dozx+2ZeZ3n61DykUK8xFoamlVZFD7iim8s1hg541xwQ/dtr3/zQ6gp5riQF8tXh5sOAiwVdLoZTpIvN9hgwB9RJ/GCxj7ug+WGkZmDHcPtCPO/zvjQc9rLVLC6o16NocpPwErGtez3MALwSh+7hLNG7ch/tSZzi3Ej81XRZpWyVY2pDq9oObxTWMFKfOvWOjKbrAnkOS1EA9djFsC5e46HlWpZlO16wbLZj6T3DT9GhuGxR//XCTwMtyCkuk=
   on:
     tags: true
-    repo: apache/incubator-openwhisk-client-js
+    repo: karanrk/incubator-openwhisk-client-js
+ 
+branches:
+  only:
+   - openwhisk-proxy

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,6 @@ deploy:
     secure: DBM6VScujsLbzNKOsZHX6/u+S7NKFbuzU/iKt20HmobUUDrCEOhL9aY+ojAw3mFktaM6M7U6fq8uazvXtqcsIy5j3prAIelZyJep1Tl1zkLptdphoa8DkDP5ErbjwN9LMZBs74PRKZDDsKJfgMDYHMw05gYsnDXhZ49V+2JCuJ5e3jidVAeXsdcF3pkxc5+YLk4IQ/ryk6bSG2VTA0U+Opcck7Z2S6JrVwvbJsLJcknsYXMMq4fttRIAXcG+yw8F8vndN9Ge50EJLsazHzyIxCPZhBNwTU9T7vwCB3XtepP+ghbb0CVI6DvfXPwPzw1iQDSOkKk8aFt77jdGV4HEdFitpukbzhmKEF6zd0SDwLkvPwafZhNNAchhv/VganFFj/ebPFtXMxI1SgvPGTsDIj6s2D6JGTgZN2BSzKRfUf0s05Dozx+2ZeZ3n61DykUK8xFoamlVZFD7iim8s1hg541xwQ/dtr3/zQ6gp5riQF8tXh5sOAiwVdLoZTpIvN9hgwB9RJ/GCxj7ug+WGkZmDHcPtCPO/zvjQc9rLVLC6o16NocpPwErGtez3MALwSh+7hLNG7ch/tSZzi3Ej81XRZpWyVY2pDq9oObxTWMFKfOvWOjKbrAnkOS1EA9djFsC5e46HlWpZlO16wbLZj6T3DT9GhuGxR//XCTwMtyCkuk=
   on:
     tags: true
-    repo: karanrk/incubator-openwhisk-client-js
+    repo: apache/incubator-openwhisk-client-js
  
-branches:
-  only:
-   - openwhisk-proxy
+

--- a/README.md
+++ b/README.md
@@ -131,6 +131,16 @@ in your options structure, e.g.
 ow.actions.invoke({ noUserAgent: true, name, params })
 ```
 
+### Working with a Proxy
+
+ If you are working behind a firewall, you could use the following environment variables to proxy your HTTP/HTTPS requests
+
+ - *http_proxy/HTTP_PROXY*
+- *https_proxy/HTTPS_proxy*
+
+ The openwhisk-client-js SDK supports the use of above mentioned proxies through third-party 
+ HTTP agent such as [proxy-agent](https://github.com/TooTallNate/node-proxy-agent "proxy-agent Github page")
+
 ## Examples
 
 ### invoke action, blocking for result

--- a/lib/client.js
+++ b/lib/client.js
@@ -35,19 +35,18 @@ const rp = opts => {
   // opts.json field to true; rp is apparently more resilient to
   // this situation than needle
   opts.json = true
-  
-  //gather proxy settings if behind a firewall
-  var proxyUri = process.env.proxy
-	|| process.env.HTTP_PROXY
-      	|| process.env.http_proxy
-      	|| process.env.HTTPS_PROXY
-      	|| process.env.https_proxy; 
 
-  if(proxyUri != undefined){
-	//set the agent with corresponding proxy
-	opts.agent = new ProxyAgent(proxyUri);
+  // gather proxy settings if behind a firewall
+  var proxyUri = process.env.proxy ||
+      process.env.HTTP_PROXY ||
+      process.env.http_proxy ||
+      process.env.HTTPS_PROXY ||
+      process.env.https_proxy
+
+  if (proxyUri !== undefined) {
+	// set the agent with corresponding proxy
+    opts.agent = new ProxyAgent(proxyUri)
   }
-
 
   return needle(opts.method.toLowerCase(), // needle takes e.g. 'put' not 'PUT'
     opts.url,

--- a/lib/client.js
+++ b/lib/client.js
@@ -44,7 +44,7 @@ const rp = opts => {
       process.env.https_proxy
 
   if (proxyUri !== undefined) {
-   // set the agent with corresponding proxy
+    // set the agent with corresponding proxy
     opts.agent = new ProxyAgent(proxyUri)
   }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -44,7 +44,7 @@ const rp = opts => {
       process.env.https_proxy
 
   if (proxyUri !== undefined) {
-	// set the agent with corresponding proxy
+   // set the agent with corresponding proxy
     opts.agent = new ProxyAgent(proxyUri)
   }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -8,7 +8,7 @@ const OpenWhiskError = require('./openwhisk_error')
 const needle = require('needle')
 const url = require('url')
 const http = require('http')
-
+const ProxyAgent = require('proxy-agent')
 /**
  * This implements a request-promise-like facade over the needle
  * library. There are two gaps between needle and rp that need to be
@@ -35,6 +35,19 @@ const rp = opts => {
   // opts.json field to true; rp is apparently more resilient to
   // this situation than needle
   opts.json = true
+  
+  //gather proxy settings if behind a firewall
+  var proxyUri = process.env.proxy
+	|| process.env.HTTP_PROXY
+      	|| process.env.http_proxy
+      	|| process.env.HTTPS_PROXY
+      	|| process.env.https_proxy; 
+
+  if(proxyUri != undefined){
+	//set the agent with corresponding proxy
+	opts.agent = new ProxyAgent(proxyUri);
+  }
+
 
   return needle(opts.method.toLowerCase(), // needle takes e.g. 'put' not 'PUT'
     opts.url,

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "standard": "^11.0.1"
   },
   "dependencies": {
-    "needle": "^2.1.0"
+    "needle": "^2.1.0",
+    "proxy-agent": "^3.0.3"
   },
   "babel": {
     "presets": [

--- a/test/unit/client.test.js
+++ b/test/unit/client.test.js
@@ -6,6 +6,7 @@
 const test = require('ava')
 const Client = require('../../lib/client')
 const http = require('http')
+const ProxyAgent = require('proxy-agent')
 
 test('should use default constructor options', t => {
   const client = new Client({api_key: 'aaa', apihost: 'my_host'})
@@ -135,6 +136,22 @@ test('should return request parameters with merged options', async t => {
   t.true(params.headers.hasOwnProperty('Authorization'))
   t.deepEqual(params.a, {foo: 'bar'})
   t.deepEqual(params.b, {bar: 'foo'})
+})
+
+test('should be able to use proxy options leveraging the proxy agent.', async t => {
+  process.env['proxy'] = 'http://some_proxy'
+  const client = new Client({api_key: 'username:password', apihost: 'blah'})
+  const METHOD = 'get'
+  const PATH = 'some/path/to/resource'
+  const OPTIONS = {agent: new ProxyAgent(process.env['proxy'])}
+
+  const params = await client.params(METHOD, PATH, OPTIONS)
+  t.is(params.method, METHOD)
+  t.true(params.json)
+  t.true(params.rejectUnauthorized)
+  t.true(params.headers.hasOwnProperty('Authorization'))
+  t.deepEqual(params.agent.proxyUri, 'http://some_proxy')
+  delete process.env['proxy']
 })
 
 test('should return request parameters with explicit api option', async t => {


### PR DESCRIPTION
This Pull Request solves the problem of openwhisk client not able to make server requests if client is behind  firewall. The client uses needle to package the parameters and options to make a HTTP request to the server, this PR uses a proxy-agent to pass through the firewall and connect to openwhisk sdk.
Files Edited : client.js and package.json