### PR TITLE
support setting the apiversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ _Client constructor supports the following mandatory parameters:_
 *Client constructor supports the following optional parameters:*
 
 - **api.** Full API URL for OpenWhisk platform, e.g. `https://openwhisk.ng.bluemix.net/api/v1/`. This value overrides `apihost` if both are present.
+- **apiversion** Api version for the OpenWhisk platform, e.g. the `v1` in `https://openwhisk.ng.bluemix.net/api/v1/`, when used with `apihost` (and `api` is not set)
 - **namespace**. Namespace for resource requests, defaults to `_`.
 - **ignore_certs**. Turns off server SSL/TLS certificate verification. This allows the client to be used against local deployments of OpenWhisk with a self-signed certificate. Defaults to false.
 - **apigw_token**. API Gateway service authentication token. This is mandatory for using an external API Gateway service, rather than the built-in api gateway.

--- a/lib/client.js
+++ b/lib/client.js
@@ -74,6 +74,7 @@ class Client {
    * @param {string} [options.api]
    * @param {string} [options.api_key]
    * @param {string} [options.apihost]
+   * @param {string} [options.apiversion]
    * @param {string} [options.namespace]
    * @param {boolean} [options.ignore_certs]
    * @param {string} [options.apigw_token]
@@ -92,9 +93,12 @@ class Client {
         ? process.env['__OW_IGNORE_CERTS'].toLowerCase() === 'true'
         : false)
 
+    // if apiversion is available, use it
+    const apiversion = options.apiversion || 'v1'
+
     // if apihost is available, parse this into full API url
     const api = options.api ||
-      this.urlFromApihost(options.apihost || process.env['__OW_API_HOST'])
+      this.urlFromApihost(options.apihost || process.env['__OW_API_HOST'], apiversion)
 
     // optional tokens for API GW service
     const apigwToken = options.apigw_token || process.env['__OW_APIGW_TOKEN']
@@ -111,12 +115,12 @@ class Client {
       throw new Error(`${messages.INVALID_OPTIONS_ERROR} Missing either api or apihost parameters.`)
     }
 
-    return {apiKey: apiKey, api, ignoreCerts: ignoreCerts, namespace: options.namespace, apigwToken: apigwToken, apigwSpaceGuid: apigwSpaceGuid, authHandler: options.auth_handler, noUserAgent: options.noUserAgent}
+    return {apiKey: apiKey, api, apiVersion: apiversion, ignoreCerts: ignoreCerts, namespace: options.namespace, apigwToken: apigwToken, apigwSpaceGuid: apigwSpaceGuid, authHandler: options.auth_handler, noUserAgent: options.noUserAgent}
   }
 
-  urlFromApihost (apihost) {
+  urlFromApihost (apihost, apiversion = 'v1') {
     if (!apihost) return apihost
-    let url = `${apihost}/api/v1/`
+    let url = `${apihost}/api/${apiversion}/`
 
     // if apihost does not the protocol, assume HTTPS
     if (!url.match(/http(s)?:\/\//)) {

--- a/test/unit/client.test.js
+++ b/test/unit/client.test.js
@@ -12,6 +12,7 @@ test('should use default constructor options', t => {
   const client = new Client({api_key: 'aaa', apihost: 'my_host'})
   t.false(client.options.ignoreCerts)
   t.is(client.options.apiKey, 'aaa')
+  t.is(client.options.apiVersion, 'v1')
   t.is(client.options.api, 'https://my_host/api/v1/')
   t.falsy(client.options.namespace)
 })
@@ -22,14 +23,26 @@ test('should support explicit constructor options', t => {
     ignore_certs: true,
     api_key: 'aaa',
     api: 'my_host',
+    apiversion: 'v2',
     apigw_token: 'oauth_token',
     apigw_space_guid: 'space_guid'
   })
   t.is(client.options.api, 'my_host')
+  t.is(client.options.apiVersion, 'v2')
   t.true(client.options.ignoreCerts)
   t.is(client.options.namespace, 'ns')
   t.is(client.options.apigwToken, 'oauth_token')
   t.is(client.options.apigwSpaceGuid, 'space_guid')
+})
+
+test('apihost and apiversion set', t => {
+  const client = new Client({
+    api_key: 'aaa',
+    apihost: 'https://my_host',
+    apiversion: 'v2'
+  })
+  t.is(client.options.api, 'https://my_host/api/v2/')
+  t.is(client.options.apiVersion, 'v2')
 })
 
 test('should support deprecated explicit constructor options', t => {


### PR DESCRIPTION
Adds support for setting the `apiversion` like the Go client.
Option is added in the Client constructor.