### PR TITLE
support adding your own cert and key

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ _Client constructor supports the following mandatory parameters:_
 - **ignore_certs**. Turns off server SSL/TLS certificate verification. This allows the client to be used against local deployments of OpenWhisk with a self-signed certificate. Defaults to false.
 - **apigw_token**. API Gateway service authentication token. This is mandatory for using an external API Gateway service, rather than the built-in api gateway.
 - **apigw_space_guid**. API Gateway space identifier. This is optional when using an API gateway service, defaults to the authentication uuid.
+- **cert**. Client cert to use when connecting to the `apihost` (if `nginx_ssl_verify_client` is turned on in your apihost)
+- **key**. Client key to use when connecting to the `apihost` (if `nginx_ssl_verify_client` is turned on in your apihost)
+
 
 ### environment variables
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -80,6 +80,8 @@ class Client {
    * @param {string} [options.apigw_space_guid]
    * @param {Function} [options.auth_handler]
    * @param {boolean} [options.noUserAgent]
+   * @param {string} [options.cert]
+   * @param {string} [options.key]
    */
   constructor (options) {
     this.options = this.parseOptions(options || {})
@@ -111,7 +113,7 @@ class Client {
       throw new Error(`${messages.INVALID_OPTIONS_ERROR} Missing either api or apihost parameters.`)
     }
 
-    return {apiKey: apiKey, api, ignoreCerts: ignoreCerts, namespace: options.namespace, apigwToken: apigwToken, apigwSpaceGuid: apigwSpaceGuid, authHandler: options.auth_handler, noUserAgent: options.noUserAgent}
+    return {apiKey: apiKey, api, ignoreCerts: ignoreCerts, namespace: options.namespace, apigwToken: apigwToken, apigwSpaceGuid: apigwSpaceGuid, authHandler: options.auth_handler, noUserAgent: options.noUserAgent, cert: options.cert, key: options.key}
   }
 
   urlFromApihost (apihost) {
@@ -143,6 +145,11 @@ class Client {
           Authorization: header
         }
       }, options)
+
+      if (this.options.cert && this.options.key) {
+        parms.cert = this.options.cert
+        parms.key = this.options.key
+      }
 
       if (this.options.noUserAgent || parms.noUserAgent) {
         // caller asked for no user agent?

--- a/test/unit/client.test.js
+++ b/test/unit/client.test.js
@@ -14,6 +14,8 @@ test('should use default constructor options', t => {
   t.is(client.options.apiKey, 'aaa')
   t.is(client.options.api, 'https://my_host/api/v1/')
   t.falsy(client.options.namespace)
+  t.falsy(client.options.cert)
+  t.falsy(client.options.key)
 })
 
 test('should support explicit constructor options', t => {
@@ -23,13 +25,17 @@ test('should support explicit constructor options', t => {
     api_key: 'aaa',
     api: 'my_host',
     apigw_token: 'oauth_token',
-    apigw_space_guid: 'space_guid'
+    apigw_space_guid: 'space_guid',
+    cert: 'mycert=',
+    key: 'mykey='
   })
   t.is(client.options.api, 'my_host')
   t.true(client.options.ignoreCerts)
   t.is(client.options.namespace, 'ns')
   t.is(client.options.apigwToken, 'oauth_token')
   t.is(client.options.apigwSpaceGuid, 'space_guid')
+  t.is(client.options.cert, 'mycert=')
+  t.is(client.options.key, 'mykey=')
 })
 
 test('should support deprecated explicit constructor options', t => {
@@ -120,6 +126,8 @@ test('should return default request parameters without options', async t => {
   t.true(params.json)
   t.true(params.rejectUnauthorized)
   t.true(params.headers.hasOwnProperty('Authorization'))
+  t.falsy(params.cert)
+  t.falsy(params.key)
 })
 
 test('should return request parameters with merged options', async t => {
@@ -136,6 +144,19 @@ test('should return request parameters with merged options', async t => {
   t.true(params.headers.hasOwnProperty('Authorization'))
   t.deepEqual(params.a, {foo: 'bar'})
   t.deepEqual(params.b, {bar: 'foo'})
+})
+
+test('should return request parameters with cert and key client options', async t => {
+  const client = new Client({api_key: 'username:password', apihost: 'blah', cert: 'mycert=', key: 'mykey='})
+  const METHOD = 'get'
+  const PATH = 'some/path/to/resource'
+  const OPTIONS = { myoption: true }
+
+  const params = await client.params(METHOD, PATH, OPTIONS)
+  t.is(params.url, 'https://blah/api/v1/some/path/to/resource')
+  t.is(params.method, METHOD)
+  t.is(params.cert, 'mycert=')
+  t.is(params.key, 'mykey=')
 })
 
 test('should be able to use proxy options leveraging the proxy agent.', async t => {


### PR DESCRIPTION
Adds support for setting the cert and key like the Go client.
Option is added in the Client constructor.