### PR TITLE
Fix scancode issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements; and to You under the Apache License, Version 2.0.
+
 language: node_js
 node_js:
 - '6'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,21 +1,22 @@
-[![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
 <!--
 #
-# Licensed to the Apache Software Foundation (ASF) under one or more contributor 
-# license agreements.  See the NOTICE file distributed with this work for additional 
-# information regarding copyright ownership.  The ASF licenses this file to you
-# under the Apache License, Version 2.0 (the # "License"); you may not use this 
-# file except in compliance with the License.  You may obtain a copy of the License 
-# at:
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
 #
-# http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing, software distributed 
-# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
-# CONDITIONS OF ANY KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations under the License.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 -->
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
 
 # Contributing to Apache OpenWhisk
 
@@ -36,18 +37,18 @@ Instructions on how to do this can be found here:
 [http://www.apache.org/licenses/#clas](http://www.apache.org/licenses/#clas)
 
 Once submitted, you will receive a confirmation email from the Apache Software Foundation (ASF) and be added to
-the following list: http://people.apache.org/unlistedclas.html. 
+the following list: http://people.apache.org/unlistedclas.html.
 
 Project committers will use this list to verify pull requests (PRs) come from contributors that have signed a CLA.
 
-We look forward to your contributions! 
+We look forward to your contributions!
 
 ## Raising issues
 
-Please raise any bug reports on the respective project repository's GitHub issue tracker. Be sure to search the 
+Please raise any bug reports on the respective project repository's GitHub issue tracker. Be sure to search the
 list to see if your issue has already been raised.
 
-A good bug report is one that make it easy for us to understand what you were trying to do and what went wrong. 
+A good bug report is one that make it easy for us to understand what you were trying to do and what went wrong.
 Provide as much context as possible so we can try to recreate the issue.
 
 ### Discussion
@@ -65,4 +66,4 @@ code base. Some basic rules include:
 
  - all files must have the Apache license in the header.
  - all PRs must have passing builds for all operating systems.
- - follow the [standard](https://standardjs.com) style rules. Linter run on CI and automatically as [pre-commit hook](http://githooks.com/). For automatic fixing run `npm run standard-fix`.  
+ - follow the [standard](https://standardjs.com) style rules. Linter run on CI and automatically as [pre-commit hook](http://githooks.com/). For automatic fixing run `npm run standard-fix`.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,21 @@
+<!--
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+-->
 # OpenWhisk Client for JavaScript
 
 [![Build Status](https://travis-ci.org/apache/incubator-openwhisk-client-js.svg?branch=master)](https://travis-ci.org/apache/incubator-openwhisk-client-js)
@@ -79,7 +97,7 @@ var options = {
 }
 var ow = openwhisk(options)
 ow.actions.invoke('sample').then(result => console.log(result))
-``` 
+```
 
 
 ### constructor options
@@ -138,7 +156,7 @@ ow.actions.invoke({ noUserAgent: true, name, params })
  - *http_proxy/HTTP_PROXY*
 - *https_proxy/HTTPS_proxy*
 
- The openwhisk-client-js SDK supports the use of above mentioned proxies through third-party 
+ The openwhisk-client-js SDK supports the use of above mentioned proxies through third-party
  HTTP agent such as [proxy-agent](https://github.com/TooTallNate/node-proxy-agent "proxy-agent Github page")
 
 ## Examples

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -1,3 +1,21 @@
+<!--
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+-->
 Integrations Test
 --
 
@@ -12,4 +30,4 @@ You can retrieve these settings from the `.wskprops` file.
 
 *Note:* If the tests fail, you might need to remove the created artifacts manually.
 
-[Alternatively](https://github.com/apache/incubator-openwhisk-client-js#integration-tests), you can run the `prepIntegrationTests.sh` script using guest credentials or by specifying specific credentials.  
+[Alternatively](https://github.com/apache/incubator-openwhisk-client-js#integration-tests), you can run the`prepIntegrationTests.sh` script using guest credentials or by specifying specific credentials.

--- a/test/integration/prepIntegrationTests.sh
+++ b/test/integration/prepIntegrationTests.sh
@@ -1,22 +1,8 @@
 #!/bin/bash
 #set -e
 
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements; and to You under the Apache License, Version 2.0.
 
 #Usage: ./test/integration/prepIntegrationTests.sh <apikeyintheformofABCD:EFGH> <openwhisk hostname> <openwhisk namespace> <api gatewaytoken> <optional "insecure">
 # Run from the incubator-openwhisk-client-js

--- a/test/integration/prepIntegrationTests.sh
+++ b/test/integration/prepIntegrationTests.sh
@@ -1,5 +1,23 @@
 #!/bin/bash
 #set -e
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 #Usage: ./test/integration/prepIntegrationTests.sh <apikeyintheformofABCD:EFGH> <openwhisk hostname> <openwhisk namespace> <api gatewaytoken> <optional "insecure">
 # Run from the incubator-openwhisk-client-js
 

--- a/test/integration/utils.js
+++ b/test/integration/utils.js
@@ -1,3 +1,6 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more contributor
+// license agreements; and to You under the Apache License, Version 2.0.
+
 function getInsecureFlag () {
   let npmConfigArgObj = process.env.npm_config_argv ? JSON.parse(process.env.npm_config_argv) : null
   if (npmConfigArgObj) {

--- a/tools/merge-coverage.sh
+++ b/tools/merge-coverage.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements; and to You under the Apache License, Version 2.0.
+
 key="$1"
 host="$2"
 namespace="$3"

--- a/tools/travis/build.sh
+++ b/tools/travis/build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 set -e
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements; and to You under the Apache License, Version 2.0.
 
 # Build script for Travis-CI.
 

--- a/tools/travis/scancode.sh
+++ b/tools/travis/scancode.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements; and to You under the Apache License, Version 2.0.
+
 # Build script for Travis-CI.
 SCRIPTDIR=$(cd $(dirname "$0") && pwd)
 ROOTDIR="$SCRIPTDIR/../.."

--- a/tools/travis/setup.sh
+++ b/tools/travis/setup.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements; and to You under the Apache License, Version 2.0.
+
 SCRIPTDIR=$(cd $(dirname "$0") && pwd)
 HOMEDIR="$SCRIPTDIR/../../../"
 

--- a/tools/travis/setupscan.sh
+++ b/tools/travis/setupscan.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements; and to You under the Apache License, Version 2.0.
 
 SCRIPTDIR=$(cd $(dirname "$0") && pwd)
 HOMEDIR="$SCRIPTDIR/../../../"


### PR DESCRIPTION
Unfortunately it still detects `test/integration/prepIntegrationTests.sh` as not being compliant:
```
./tools/travis/scancode.sh
Reading configuration file [/Users/shaz/git/apache/openwhisk/incubator-openwhisk-utilities/scancode/ASF-Release.cfg]...
Scanning files starting at [/Users/shaz/git/apache/openwhisk/incubator-openwhisk-client-js/tools/travis/../..]...
Scan detected 6 error(s) in 6 file(s):
  [/Users/shaz/git/apache/openwhisk/incubator-openwhisk-client-js/tools/travis/../../test/integration/prepIntegrationTests.sh]:
       1: file does not include required license header.
  [/Users/shaz/git/apache/openwhisk/incubator-openwhisk-client-js/tools/travis/../../tools/merge-coverage.sh]:
       1: file does not include required license header.
  [/Users/shaz/git/apache/openwhisk/incubator-openwhisk-client-js/tools/travis/../../tools/travis/build.sh]:
       1: file does not include required license header.
  [/Users/shaz/git/apache/openwhisk/incubator-openwhisk-client-js/tools/travis/../../tools/travis/scancode.sh]:
       1: file does not include required license header.
  [/Users/shaz/git/apache/openwhisk/incubator-openwhisk-client-js/tools/travis/../../tools/travis/setup.sh]:
       1: file does not include required license header.
  [/Users/shaz/git/apache/openwhisk/incubator-openwhisk-client-js/tools/travis/../../tools/travis/setupscan.sh]:
       1: file does not include required license header.

Scan detected 6 error(s) in 6 file(s):
```
.. this is because the license does not start at the first line. We can't put the license on the first line because for shell scripts the shebang must be on the first line. This of course affects the other shell scripts in `tools/travis` as well...

During local testing I couldn't figure out (yet) how to add exclusions to `node_modules` (deleted that)...