### PR TITLE
Add Incubation Disclaimer to bottom of README.ms

### DIFF
--- a/README.md
+++ b/README.md
@@ -633,3 +633,6 @@ To generate combined reports of both the unit and integration tests, run the fol
 2 `$ npm run code-coverage-run <key> <host> <namespace> <token> <options>`
 
 The report is viewable under `/coverage`. Click **`/coverage/index.html`** to view the full report.
+
+# Disclaimer
+Apache OpenWhisk JavaScript Client Library is an effort undergoing incubation at The Apache Software Foundation (ASF), sponsored by the Apache Incubator. Incubation is required of all newly accepted projects until a further review indicates that the infrastructure, communications, and decision making process have stabilized in a manner consistent with other successful ASF projects. While incubation status is not necessarily a reflection of the completeness or stability of the code, it does indicate that the project has yet to be fully endorsed by the ASF.


### PR DESCRIPTION
As per other openwhisk git repos; the incubation disclaimer is replicated in both Disclaimer.txt and at the bottom of the top-level README.ms