### PR TITLE
Remove unnecessary node-proxy-agent dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 -->
-# OpenWhisk Client for JavaScript
+# Apache OpenWhisk Client for JavaScript
 
 [![Build Status](https://travis-ci.org/apache/incubator-openwhisk-client-js.svg?branch=master)](https://travis-ci.org/apache/incubator-openwhisk-client-js)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
@@ -117,6 +117,8 @@ _Client constructor supports the following mandatory parameters:_
 - **apigw_space_guid**. API Gateway space identifier. This is optional when using an API gateway service, defaults to the authentication uuid.
 - **cert**. Client cert to use when connecting to the `apihost` (if `nginx_ssl_verify_client` is turned on in your apihost)
 - **key**. Client key to use when connecting to the `apihost` (if `nginx_ssl_verify_client` is turned on in your apihost)
+- **proxy.** HTTP(s) URI for proxy service to forwards requests through. Uses Needle's [built-in proxy support](https://github.com/tomas/needle#request-options).
+- **agent.** Provide custom [http.Agent](https://nodejs.org/api/http.html#http_class_http_agent) implementation.
 
 
 ### environment variables
@@ -155,13 +157,13 @@ ow.actions.invoke({ noUserAgent: true, name, params })
 
 ### Working with a Proxy
 
- If you are working behind a firewall, you could use the following environment variables to proxy your HTTP/HTTPS requests
+If you are working behind a firewall, HTTP(s) proxy details can be set by using the `proxy` option in the constructor parameters with the proxy service URI, e.g. `http://proxy-server.com:3128`. The proxy URI can also be set using the following environment parameters (to set a proxy without changing application code):
 
- - *http_proxy/HTTP_PROXY*
-- *https_proxy/HTTPS_proxy*
+ - *proxy or PROXY*
+ - *http_proxy or HTTP_PROXY*
+- *https_proxy or HTTPS_proxy*
 
- The openwhisk-client-js SDK supports the use of above mentioned proxies through third-party
- HTTP agent such as [proxy-agent](https://github.com/TooTallNate/node-proxy-agent "proxy-agent Github page")
+If you need more advanced proxy behaviour, rather than using Needle's default [built-in HTTP agent](https://github.com/tomas/needle), the `agent` constructor parameter can be used to set a custom `http.Agent` implementation, e.g [proxy-agent](https://github.com/TooTallNate/node-proxy-agent "proxy-agent Github page")
 
 ## Examples
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -8,7 +8,7 @@ const OpenWhiskError = require('./openwhisk_error')
 const needle = require('needle')
 const url = require('url')
 const http = require('http')
-const ProxyAgent = require('proxy-agent')
+
 /**
  * This implements a request-promise-like facade over the needle
  * library. There are two gaps between needle and rp that need to be
@@ -35,18 +35,6 @@ const rp = opts => {
   // opts.json field to true; rp is apparently more resilient to
   // this situation than needle
   opts.json = true
-
-  // gather proxy settings if behind a firewall
-  var proxyUri = process.env.proxy ||
-      process.env.HTTP_PROXY ||
-      process.env.http_proxy ||
-      process.env.HTTPS_PROXY ||
-      process.env.https_proxy
-
-  if (proxyUri !== undefined) {
-    // set the agent with corresponding proxy
-    opts.agent = new ProxyAgent(proxyUri)
-  }
 
   return needle(opts.method.toLowerCase(), // needle takes e.g. 'put' not 'PUT'
     opts.url,
@@ -95,6 +83,14 @@ class Client {
         ? process.env['__OW_IGNORE_CERTS'].toLowerCase() === 'true'
         : false)
 
+    // gather proxy settings if behind a firewall
+    const proxy = options.proxy || process.env.PROXY || process.env.proxy ||
+      process.env.HTTP_PROXY || process.env.http_proxy ||
+      process.env.HTTPS_PROXY || process.env.https_proxy
+
+    // custom HTTP agent
+    const agent = options.agent
+
     // if apiversion is available, use it
     const apiversion = options.apiversion || 'v1'
 
@@ -117,7 +113,7 @@ class Client {
       throw new Error(`${messages.INVALID_OPTIONS_ERROR} Missing either api or apihost parameters.`)
     }
 
-    return {apiKey: apiKey, api, apiVersion: apiversion, ignoreCerts: ignoreCerts, namespace: options.namespace, apigwToken: apigwToken, apigwSpaceGuid: apigwSpaceGuid, authHandler: options.auth_handler, noUserAgent: options.noUserAgent, cert: options.cert, key: options.key}
+    return {apiKey: apiKey, api, apiVersion: apiversion, ignoreCerts: ignoreCerts, namespace: options.namespace, apigwToken: apigwToken, apigwSpaceGuid: apigwSpaceGuid, authHandler: options.auth_handler, noUserAgent: options.noUserAgent, cert: options.cert, key: options.key, proxy, agent}
   }
 
   urlFromApihost (apihost, apiversion = 'v1') {
@@ -162,6 +158,14 @@ class Client {
       if (typeof this.options.namespace === 'string') {
         // identify namespace targeting a public/shared entity
         parms.headers['x-namespace-id'] = this.options.namespace
+      }
+
+      if (this.options.proxy) {
+        parms.proxy = this.options.proxy
+      }
+
+      if (this.options.agent) {
+        parms.agent = this.options.agent
       }
 
       return parms

--- a/package.json
+++ b/package.json
@@ -54,8 +54,7 @@
     "standard": "^11.0.1"
   },
   "dependencies": {
-    "needle": "^2.1.0",
-    "proxy-agent": "^3.0.3"
+    "needle": "^2.1.0"
   },
   "babel": {
     "presets": [


### PR DESCRIPTION
This removes the increase in download size that happened when adding the proxy feature.
Maintain proxy feature using needle's built-in proxy support.
Added ability to set custom agent using constructor option.

Fixes #158