### PR TITLE
Allow environment level set of default user-agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Client constructor will read values for the `apihost`, `namespace`, `api_key`, `
 - *__OW_IGNORE_CERTS*
 - *__OW_APIGW_TOKEN*
 - *__OW_APIGW_SPACE_SUID*
+- *__OW_USER_AGENT*
 
 ### User-Agent
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -141,7 +141,7 @@ class Client {
         url: this.pathUrl(path),
         rejectUnauthorized: !this.options.ignoreCerts,
         headers: {
-          'User-Agent': (options && options['User-Agent']) || process.env['USER_AGENT'] || 'openwhisk-client-js',
+          'User-Agent': (options && options['User-Agent']) || process.env['__OW_USER_AGENT'] || 'openwhisk-client-js',
           Authorization: header
         }
       }, options)

--- a/lib/client.js
+++ b/lib/client.js
@@ -141,7 +141,7 @@ class Client {
         url: this.pathUrl(path),
         rejectUnauthorized: !this.options.ignoreCerts,
         headers: {
-          'User-Agent': (options && options['User-Agent']) || 'openwhisk-client-js',
+          'User-Agent': (options && options['User-Agent']) || process.env['USER_AGENT'] || 'openwhisk-client-js',
           Authorization: header
         }
       }, options)

--- a/test/unit/actions.test.js
+++ b/test/unit/actions.test.js
@@ -521,6 +521,24 @@ test('should pass through requested User-Agent header', t => {
   return actions.create({name: '12345', action, version, 'User-Agent': userAgent})
 })
 
+test('should pass through requested User-Agent header even when __OW_USER_AGENT is set', t => {
+  t.plan(1)
+  process.env['__OW_USER_AGENT'] = 'my-useragent'
+
+  const userAgent = 'userAgentShouldPassThroughPlease'
+  const client = {}
+  const actions = new Actions(client)
+  const action = 'function main() { // main function body};'
+  const version = '1.0.0'
+
+  client.request = (method, path, options) => {
+    t.is(options['User-Agent'], userAgent)
+    delete process.env['__OW_USER_AGENT']
+  }
+
+  return actions.create({name: '12345', action, version, 'User-Agent': userAgent})
+})
+
 test('should pass through exec.image parameter', t => {
   t.plan(1)
   const image = 'openwhisk/action-nodejs-v8:latest'

--- a/test/unit/namespaces.test.js
+++ b/test/unit/namespaces.test.js
@@ -93,6 +93,76 @@ test('should list all namespaces, NOT passing through user-agent header (variant
   return namespaces.list({noUserAgent: true})
 })
 
+test('should list all namespaces, using __OW_USER_AGENT', t => {
+  t.plan(3)
+  const client = {}
+  process.env['__OW_USER_AGENT'] = 'my-useragent'
+  client.request = async (method, path, options) => {
+    t.is(method, 'GET')
+    t.is(path, `namespaces`)
+
+    const parms = await new Client({api: 'aaa', api_key: 'aaa'}).params(method, path, options)
+    t.is(parms.headers['User-Agent'], 'my-useragent')
+    delete process.env['__OW_USER_AGENT']
+  }
+
+  const namespaces = new Namespaces(client)
+  return namespaces.list({})
+})
+
+test('should list all namespaces, NOT using __OW_USER_AGENT when noUserAgent true', t => {
+  t.plan(3)
+  const client = {}
+  process.env['__OW_USER_AGENT'] = 'my-useragent'
+  client.request = async (method, path, options) => {
+    t.is(method, 'GET')
+    t.is(path, `namespaces`)
+
+    const parms = await new Client({api: 'aaa', api_key: 'aaa', noUserAgent: true}).params(method, path, options)
+    t.is(parms.headers['User-Agent'], undefined)
+    delete process.env['__OW_USER_AGENT']
+  }
+
+  const namespaces = new Namespaces(client)
+  return namespaces.list({})
+})
+
+test('should list all namespaces, NOT using __OW_USER_AGENT when user-agent is passed through', t => {
+  t.plan(3)
+  const client = {}
+  const userAgent = 'userAgentShouldPassThroughPlease'
+  process.env['__OW_USER_AGENT'] = 'my-useragent'
+  client.request = async (method, path, options) => {
+    t.is(method, 'GET')
+    t.is(path, `namespaces`)
+
+    const parms = await new Client({api: 'aaa', api_key: 'aaa'}).params(method, path, options)
+    t.is(parms.headers['User-Agent'], userAgent)
+    delete process.env['__OW_USER_AGENT']
+  }
+
+  const namespaces = new Namespaces(client)
+  return namespaces.list({'User-Agent': userAgent})
+})
+
+test('should list all namespaces, NOT using __OW_USER_AGENT or user-agent when noUserAgent is true', t => {
+  t.plan(3)
+  const client = {}
+  const userAgent = 'userAgentShouldPassThroughPlease'
+  process.env['__OW_USER_AGENT'] = 'my-useragent'
+  client.request = async (method, path, options) => {
+    t.is(method, 'GET')
+    t.is(path, `namespaces`)
+
+    const parms = await new Client({api: 'aaa', api_key: 'aaa', noUserAgent: true}).params(method, path, options)
+    t.is(parms.headers['User-Agent'], undefined)
+    delete process.env['__OW_USER_AGENT']
+  }
+
+  const namespaces = new Namespaces(client)
+  return namespaces.list({'User-Agent': userAgent})
+})
+
 test('should retrieve namespace entities', t => {
   t.plan(16)
   const client = {}


### PR DESCRIPTION
Currently it is very difficult to set the user agent globally.
We have a library which is using this library, and changing the user-agent to something we can track requires modifying the options to every client call.