### PR TITLE
Replacing short-form license headers & fixing code lint issues.

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -1,5 +1,19 @@
-// Licensed to the Apache Software Foundation (ASF) under one or more contributor
-// license agreements; and to You under the Apache License, Version 2.0.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 'use strict'
 
@@ -45,7 +59,7 @@ class Actions extends Resources {
   }
 
   actionBodyWithCode (options) {
-    const body = {exec: {kind: options.kind || 'nodejs:default', code: options.action}}
+    const body = { exec: { kind: options.kind || 'nodejs:default', code: options.action } }
 
     // allow options to override the derived exec object
     if (options.exec) {
@@ -68,7 +82,7 @@ class Actions extends Resources {
       throw new Error(messages.INVALID_SEQ_PARAMETER_LENGTH)
     }
 
-    const body = {exec: {kind: 'sequence', components: options.sequence}}
+    const body = { exec: { kind: 'sequence', components: options.sequence } }
     return body
   }
 
@@ -94,7 +108,7 @@ class Actions extends Resources {
       ? this.actionBodyWithCode(options) : this.actionBodyWithSequence(options)
 
     if (typeof options.params === 'object') {
-      body.parameters = Object.keys(options.params).map(key => ({key, value: options.params[key]}))
+      body.parameters = Object.keys(options.params).map(key => ({ key, value: options.params[key] }))
     }
 
     if (options.version) {

--- a/lib/activations.js
+++ b/lib/activations.js
@@ -1,5 +1,19 @@
-// Licensed to the Apache Software Foundation (ASF) under one or more contributor
-// license agreements; and to You under the Apache License, Version 2.0.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 'use strict'
 

--- a/lib/base_operation.js
+++ b/lib/base_operation.js
@@ -1,5 +1,19 @@
-// Licensed to the Apache Software Foundation (ASF) under one or more contributor
-// license agreements; and to You under the Apache License, Version 2.0.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 'use strict'
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,5 +1,19 @@
-// Licensed to the Apache Software Foundation (ASF) under one or more contributor
-// license agreements; and to You under the Apache License, Version 2.0.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 'use strict'
 
@@ -113,7 +127,7 @@ class Client {
       throw new Error(`${messages.INVALID_OPTIONS_ERROR} Missing either api or apihost parameters.`)
     }
 
-    return {apiKey: apiKey, api, apiVersion: apiversion, ignoreCerts: ignoreCerts, namespace: options.namespace, apigwToken: apigwToken, apigwSpaceGuid: apigwSpaceGuid, authHandler: options.auth_handler, noUserAgent: options.noUserAgent, cert: options.cert, key: options.key, proxy, agent}
+    return { apiKey: apiKey, api, apiVersion: apiversion, ignoreCerts: ignoreCerts, namespace: options.namespace, apigwToken: apigwToken, apigwSpaceGuid: apigwSpaceGuid, authHandler: options.auth_handler, noUserAgent: options.noUserAgent, cert: options.cert, key: options.key, proxy, agent }
   }
 
   urlFromApihost (apihost, apiversion = 'v1') {

--- a/lib/feeds.js
+++ b/lib/feeds.js
@@ -1,5 +1,19 @@
-// Licensed to the Apache Software Foundation (ASF) under one or more contributor
-// license agreements; and to You under the Apache License, Version 2.0.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 'use strict'
 

--- a/lib/main.d.ts
+++ b/lib/main.d.ts
@@ -1,5 +1,19 @@
-// Licensed to the Apache Software Foundation (ASF) under one or more contributor
-// license agreements; and to You under the Apache License, Version 2.0.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 import * as Swagger from 'swagger-schema-official'
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,5 +1,19 @@
-// Licensed to the Apache Software Foundation (ASF) under one or more contributor
-// license agreements; and to You under the Apache License, Version 2.0.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 const Actions = require('./actions.js')
 const Activations = require('./activations.js')

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -1,5 +1,19 @@
-// Licensed to the Apache Software Foundation (ASF) under one or more contributor
-// license agreements; and to You under the Apache License, Version 2.0.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 module.exports = {
   MISSING_FEED_NAME_ERROR: 'Missing mandatory feedName or id parameters from options.',

--- a/lib/names.js
+++ b/lib/names.js
@@ -1,5 +1,19 @@
-// Licensed to the Apache Software Foundation (ASF) under one or more contributor
-// license agreements; and to You under the Apache License, Version 2.0.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 const messages = require('./messages')
 

--- a/lib/namespaces.js
+++ b/lib/namespaces.js
@@ -1,5 +1,19 @@
-// Licensed to the Apache Software Foundation (ASF) under one or more contributor
-// license agreements; and to You under the Apache License, Version 2.0.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 'use strict'
 
@@ -17,7 +31,7 @@ class Namespaces extends BaseOperation {
     let rules = this.client.request('GET', 'namespaces/_/rules', options)
     return Promise
       .all([actions, packages, triggers, rules])
-      .then(([actions, packages, triggers, rules]) => ({actions, packages, triggers, rules}))
+      .then(([actions, packages, triggers, rules]) => ({ actions, packages, triggers, rules }))
   }
 }
 

--- a/lib/openwhisk_error.js
+++ b/lib/openwhisk_error.js
@@ -1,5 +1,19 @@
-// Licensed to the Apache Software Foundation (ASF) under one or more contributor
-// license agreements; and to You under the Apache License, Version 2.0.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 'use strict'
 

--- a/lib/packages.js
+++ b/lib/packages.js
@@ -1,5 +1,19 @@
-// Licensed to the Apache Software Foundation (ASF) under one or more contributor
-// license agreements; and to You under the Apache License, Version 2.0.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 'use strict'
 

--- a/lib/resources.js
+++ b/lib/resources.js
@@ -1,5 +1,19 @@
-// Licensed to the Apache Software Foundation (ASF) under one or more contributor
-// license agreements; and to You under the Apache License, Version 2.0.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 'use strict'
 
@@ -47,7 +61,7 @@ class Resources extends BaseOperation {
   operation (method, options) {
     options = this.parseOptions(options)
     const id = options.id
-    return this.request({method, id, options})
+    return this.request({ method, id, options })
   }
 
   operationWithId (method, options) {
@@ -63,7 +77,7 @@ class Resources extends BaseOperation {
 
   parseOptions (options) {
     if (typeof options === 'string') {
-      options = {name: options}
+      options = { name: options }
     }
 
     return options || {}

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -1,5 +1,19 @@
-// Licensed to the Apache Software Foundation (ASF) under one or more contributor
-// license agreements; and to You under the Apache License, Version 2.0.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 'use strict'
 

--- a/lib/rules.js
+++ b/lib/rules.js
@@ -1,5 +1,19 @@
-// Licensed to the Apache Software Foundation (ASF) under one or more contributor
-// license agreements; and to You under the Apache License, Version 2.0.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 'use strict'
 
@@ -51,13 +65,13 @@ class Rules extends Resources {
 
   enable (options) {
     options = options || {}
-    options.params = {status: 'active'}
+    options.params = { status: 'active' }
     return super.invoke(options)
   }
 
   disable (options) {
     options = options || {}
-    options.params = {status: 'inactive'}
+    options.params = { status: 'inactive' }
     return super.invoke(options)
   }
 

--- a/lib/triggers.js
+++ b/lib/triggers.js
@@ -1,5 +1,19 @@
-// Licensed to the Apache Software Foundation (ASF) under one or more contributor
-// license agreements; and to You under the Apache License, Version 2.0.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 'use strict'
 

--- a/test/integration/actions.test.js
+++ b/test/integration/actions.test.js
@@ -1,5 +1,19 @@
-// Licensed to the Apache Software Foundation (ASF) under one or more contributor
-// license agreements; and to You under the Apache License, Version 2.0.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 'use strict'
 
@@ -38,7 +52,7 @@ test('list all actions using default namespace', t => {
 
 test('list all actions using options namespace', t => {
   const actions = new Actions(new Client(options))
-  return actions.list({namespace: NAMESPACE}).then(result => {
+  return actions.list({ namespace: NAMESPACE }).then(result => {
     t.true(Array.isArray(result))
     result.forEach(action => {
       t.is(action.namespace, NAMESPACE)
@@ -52,22 +66,22 @@ test('list all actions using options namespace', t => {
 
 test('get a non-existing action, expecting 404', async t => {
   const actions = new Actions(new Client(options))
-  await actions.get({name: 'glorfindel'}).catch(err => {
+  await actions.get({ name: 'glorfindel' }).catch(err => {
     t.is(err.statusCode, 404)
   })
 })
 
 test('delete a non-existing action, expecting 404', async t => {
   const actions = new Actions(new Client(options))
-  await actions.delete({name: 'glorfindel'}).catch(err => {
+  await actions.delete({ name: 'glorfindel' }).catch(err => {
     t.is(err.statusCode, 404)
   })
 })
 
 test('create with an existing action, expecting 409', async t => {
   const actions = new Actions(new Client(options))
-  await actions.create({name: 'glorfindel2', action: 'x=>x'})
-    .then(() => actions.create({name: 'glorfindel2', action: 'x=>x'}))
+  await actions.create({ name: 'glorfindel2', action: 'x=>x' })
+    .then(() => actions.create({ name: 'glorfindel2', action: 'x=>x' }))
     .catch(err => {
       t.is(err.statusCode, 409)
     })
@@ -88,11 +102,11 @@ test('create, get and delete an action', t => {
     t.is(result.namespace, NAMESPACE)
     t.true(result.exec.kind.startsWith('nodejs'))
     t.is(result.exec.code, 'function main() {return {payload:"testing"}}')
-    return actions.get({actionName: 'random_action_test'}).then(actionResult => {
+    return actions.get({ actionName: 'random_action_test' }).then(actionResult => {
       t.is(actionResult.name, 'random_action_test')
       t.is(actionResult.namespace, NAMESPACE)
       t.pass()
-      return actions.delete({actionName: 'random_action_test'}).catch(errors)
+      return actions.delete({ actionName: 'random_action_test' }).catch(errors)
     }).catch(errors)
   }).catch(errors)
 })
@@ -112,10 +126,10 @@ test('create and update an action', t => {
     t.is(result.namespace, NAMESPACE)
     t.true(result.exec.kind.startsWith('nodejs'))
     t.is(result.exec.code, 'function main() {return {payload:"testing"}}')
-    return actions.update({actionName: 'random_update_tested', action: 'update test'}).then(updateResult => {
+    return actions.update({ actionName: 'random_update_tested', action: 'update test' }).then(updateResult => {
       t.is(updateResult.exec.code, 'update test')
       t.pass()
-      return actions.delete({actionName: 'random_update_tested'}).catch(errors)
+      return actions.delete({ actionName: 'random_update_tested' }).catch(errors)
     }).catch(errors)
   }).catch(errors)
 })
@@ -129,24 +143,24 @@ test('create, get and delete with parameters an action', t => {
   const actions = new Actions(new Client(options))
   return actions.create({
     name: 'random_action_params_test',
-    params: {hello: 'world'},
+    params: { hello: 'world' },
     action: 'function main() {return {payload:"testing"}}'
   }).then(result => {
     t.is(result.name, 'random_action_params_test')
     t.is(result.namespace, NAMESPACE)
-    t.deepEqual(result.parameters, [{key: 'hello', value: 'world'}])
+    t.deepEqual(result.parameters, [{ key: 'hello', value: 'world' }])
     t.true(result.exec.kind.startsWith('nodejs'))
     t.is(result.exec.code, 'function main() {return {payload:"testing"}}')
     return actions.update({
       actionName: 'random_action_params_test',
-      params: {foo: 'bar'},
+      params: { foo: 'bar' },
       action: 'update test'
     }).then(updateResult => {
       t.is(updateResult.name, 'random_action_params_test')
       t.is(updateResult.namespace, NAMESPACE)
-      t.deepEqual(updateResult.parameters, [{key: 'foo', value: 'bar'}])
+      t.deepEqual(updateResult.parameters, [{ key: 'foo', value: 'bar' }])
       t.pass()
-      return actions.delete({name: 'random_action_params_test'}).catch(errors)
+      return actions.delete({ name: 'random_action_params_test' }).catch(errors)
     }).catch(errors)
   }).catch(errors)
 })
@@ -158,25 +172,25 @@ test('get an action with and without its code', t => {
   }
 
   const actions = new Actions(new Client(options))
-  return actions.create({actionName: 'random_action_get_test', action: 'function main() {return {payload:"testing"}}'}).then(result => {
+  return actions.create({ actionName: 'random_action_get_test', action: 'function main() {return {payload:"testing"}}' }).then(result => {
     t.is(result.name, 'random_action_get_test')
     t.is(result.namespace, NAMESPACE)
     t.true(result.exec.kind.startsWith('nodejs'))
     t.is(result.exec.code, 'function main() {return {payload:"testing"}}')
-    return actions.get({actionName: 'random_action_get_test', code: false}).then(actionResult => {
+    return actions.get({ actionName: 'random_action_get_test', code: false }).then(actionResult => {
       t.is(actionResult.name, 'random_action_get_test')
       t.is(actionResult.namespace, NAMESPACE)
       t.is(actionResult.exec.code, undefined)
-      return actions.get({actionName: 'random_action_get_test', code: true}).then(actionResult => {
+      return actions.get({ actionName: 'random_action_get_test', code: true }).then(actionResult => {
         t.is(actionResult.name, 'random_action_get_test')
         t.is(actionResult.namespace, NAMESPACE)
         t.is(actionResult.exec.code, 'function main() {return {payload:"testing"}}')
-        return actions.get({actionName: 'random_action_get_test'}).then(actionTesult => {
+        return actions.get({ actionName: 'random_action_get_test' }).then(actionTesult => {
           t.is(actionTesult.name, 'random_action_get_test')
           t.is(actionTesult.namespace, NAMESPACE)
           t.is(actionTesult.exec.code, 'function main() {return {payload:"testing"}}')
           t.pass()
-          return actions.delete({actionName: 'random_action_get_test'}).catch(errors)
+          return actions.delete({ actionName: 'random_action_get_test' }).catch(errors)
         }).catch(errors)
       }).catch(errors)
     }).catch(errors)
@@ -191,7 +205,7 @@ test('invoke action with fully-qualified name', t => {
   }
 
   const actions = new Actions(new Client(options))
-  return actions.invoke({actionName: '/whisk.system/utils/sort', blocking: true}).then(invokeResult => {
+  return actions.invoke({ actionName: '/whisk.system/utils/sort', blocking: true }).then(invokeResult => {
     t.true(invokeResult.response.success)
     t.pass()
   }).catch(errors)
@@ -205,21 +219,21 @@ test('create, invoke and remove package action', t => {
   }
 
   const zip = new JSZip()
-  zip.file('package.json', JSON.stringify({main: 'index.js'}))
+  zip.file('package.json', JSON.stringify({ main: 'index.js' }))
   zip.file('index.js', 'function main(params) {return params};\nexports.main = main;')
 
-  return zip.generateAsync({type: 'nodebuffer'}).then(content => {
+  return zip.generateAsync({ type: 'nodebuffer' }).then(content => {
     const actions = new Actions(new Client(options))
-    return actions.create({actionName: 'random_package_action_test', action: content}).then(result => {
+    return actions.create({ actionName: 'random_package_action_test', action: content }).then(result => {
       return actions.invoke({
         actionName: 'random_package_action_test',
-        params: {hello: 'world'},
+        params: { hello: 'world' },
         blocking: true
       }).then(invokeResult => {
-        t.deepEqual(invokeResult.response.result, {hello: 'world'})
+        t.deepEqual(invokeResult.response.result, { hello: 'world' })
         t.true(invokeResult.response.success)
         t.pass()
-        return actions.delete({actionName: 'random_package_action_test'}).catch(errors)
+        return actions.delete({ actionName: 'random_package_action_test' }).catch(errors)
       })
     })
   }).catch(errors)
@@ -240,11 +254,11 @@ test('create, get and delete sequence action', t => {
     t.is(result.namespace, NAMESPACE)
     t.is(result.exec.kind, 'sequence')
     t.deepEqual(result.exec.components, ['/whisk.system/utils/echo'])
-    return actions.get({actionName: 'my_sequence'}).then(actionResult => {
+    return actions.get({ actionName: 'my_sequence' }).then(actionResult => {
       t.is(actionResult.name, 'my_sequence')
       t.is(actionResult.namespace, NAMESPACE)
       t.pass()
-      return actions.delete({actionName: 'my_sequence'}).catch(errors)
+      return actions.delete({ actionName: 'my_sequence' }).catch(errors)
     }).catch(errors)
   }).catch(errors)
 })

--- a/test/integration/activations.test.js
+++ b/test/integration/activations.test.js
@@ -1,5 +1,19 @@
-// Licensed to the Apache Software Foundation (ASF) under one or more contributor
-// license agreements; and to You under the Apache License, Version 2.0.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 'use strict'
 
@@ -37,7 +51,7 @@ test('retrieve individual activations', t => {
   const activations = new Activations(new Client(options))
   return activations.list().then(result => {
     t.true(Array.isArray(result))
-    return Promise.all(result.map(r => activations.get({activation: r.activationId})))
+    return Promise.all(result.map(r => activations.get({ activation: r.activationId })))
   }).catch(err => {
     console.log(err)
     t.fail()
@@ -48,7 +62,7 @@ test('retrieve individual activation logs', t => {
   const activations = new Activations(new Client(options))
   return activations.list().then(result => {
     t.true(Array.isArray(result))
-    return Promise.all(result.map(r => activations.logs({activation: r.activationId})))
+    return Promise.all(result.map(r => activations.logs({ activation: r.activationId })))
   }).catch(err => {
     console.log(err)
     t.fail()
@@ -59,7 +73,7 @@ test('retrieve individual activation result', t => {
   const activations = new Activations(new Client(options))
   return activations.list().then(result => {
     t.true(Array.isArray(result))
-    return Promise.all(result.map(r => activations.result({activation: r.activationId})))
+    return Promise.all(result.map(r => activations.result({ activation: r.activationId })))
   }).catch(err => {
     console.log(err)
     t.fail()

--- a/test/integration/feeds.test.js
+++ b/test/integration/feeds.test.js
@@ -1,5 +1,19 @@
-// Licensed to the Apache Software Foundation (ASF) under one or more contributor
-// license agreements; and to You under the Apache License, Version 2.0.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 'use strict'
 
@@ -29,11 +43,11 @@ tempTest('create, get, update, and delete a feed', async t => {
   const feedParams = {
     feedName: '/whisk.system/alarms/alarm',
     trigger: `/${NAMESPACE}/sample_feed_trigger`,
-    params: {cron: '*/8 * * * * *', trigger_payload: {name: 'test', place: 'hello'}}
+    params: { cron: '*/8 * * * * *', trigger_payload: { name: 'test', place: 'hello' } }
   }
 
   try {
-    await triggers.create({triggerName: 'sample_feed_trigger'})
+    await triggers.create({ triggerName: 'sample_feed_trigger' })
     const result = await feeds.create(feedParams)
     t.is(result.response.success, true)
 
@@ -47,7 +61,7 @@ tempTest('create, get, update, and delete a feed', async t => {
     const deleteResult = await feeds.delete(feedParams)
     t.is(deleteResult.response.success, true)
 
-    await triggers.delete({triggerName: 'sample_feed_trigger'})
+    await triggers.delete({ triggerName: 'sample_feed_trigger' })
     t.pass()
   } catch (err) {
     console.log(err)

--- a/test/integration/namespaces.test.js
+++ b/test/integration/namespaces.test.js
@@ -1,5 +1,19 @@
-// Licensed to the Apache Software Foundation (ASF) under one or more contributor
-// license agreements; and to You under the Apache License, Version 2.0.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 'use strict'
 
@@ -34,7 +48,7 @@ test('retrieve individual namespaces', t => {
   const namespaces = new Namespaces(new Client(options))
   return namespaces.list().then(result => {
     t.true(Array.isArray(result))
-    return Promise.all(result.map(ns => namespaces.get({namespace: ns})))
+    return Promise.all(result.map(ns => namespaces.get({ namespace: ns })))
   }).catch(err => {
     console.log(err)
     t.fail()

--- a/test/integration/packages.test.js
+++ b/test/integration/packages.test.js
@@ -1,5 +1,19 @@
-// Licensed to the Apache Software Foundation (ASF) under one or more contributor
-// license agreements; and to You under the Apache License, Version 2.0.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 'use strict'
 
@@ -37,7 +51,7 @@ test('list all packages using default namespace', t => {
 
 test('list all packages using options namespace', t => {
   const packages = new Packages(new Client(options))
-  return packages.list({namespace: NAMESPACE}).then(result => {
+  return packages.list({ namespace: NAMESPACE }).then(result => {
     t.true(Array.isArray(result))
     result.forEach(packageName => {
       t.is(packageName.namespace, NAMESPACE)
@@ -51,7 +65,7 @@ test('list all packages using options namespace', t => {
 
 test('get a non-existing package, expecting 404', async t => {
   const packages = new Packages(new Client(options))
-  await packages.get({name: 'glorfindel'}).catch(err => {
+  await packages.get({ name: 'glorfindel' }).catch(err => {
     t.is(err.statusCode, 404)
   })
 })
@@ -63,16 +77,16 @@ test('create, get and delete an package', t => {
   }
 
   const packages = new Packages(new Client(options))
-  return packages.create({packageName: 'random_package_test'}).then(result => {
+  return packages.create({ packageName: 'random_package_test' }).then(result => {
     t.is(result.name, 'random_package_test')
     t.is(result.namespace, NAMESPACE)
     t.deepEqual(result.annotations, [])
     t.is(result.version, '0.0.1')
-    return packages.get({packageName: 'random_package_test'}).then(packageResult => {
+    return packages.get({ packageName: 'random_package_test' }).then(packageResult => {
       t.is(packageResult.name, 'random_package_test')
       t.is(packageResult.namespace, NAMESPACE)
       t.pass()
-      return packages.delete({packageName: 'random_package_test'}).catch(errors)
+      return packages.delete({ packageName: 'random_package_test' }).catch(errors)
     }).catch(errors)
   }).catch(errors)
 })
@@ -84,15 +98,15 @@ test('create and update an package', t => {
   }
 
   const packages = new Packages(new Client(options))
-  return packages.create({packageName: 'random_package_update_test'}).then(result => {
+  return packages.create({ packageName: 'random_package_update_test' }).then(result => {
     t.is(result.name, 'random_package_update_test')
     t.is(result.namespace, NAMESPACE)
     t.deepEqual(result.annotations, [])
     t.is(result.version, '0.0.1')
-    return packages.update({packageName: 'random_package_update_test'}).then(updateResult => {
+    return packages.update({ packageName: 'random_package_update_test' }).then(updateResult => {
       t.is(updateResult.version, '0.0.2')
       t.pass()
-      return packages.delete({packageName: 'random_package_update_test'}).catch(errors)
+      return packages.delete({ packageName: 'random_package_update_test' }).catch(errors)
     }).catch(errors)
   }).catch(errors)
 })

--- a/test/integration/routes.test.js
+++ b/test/integration/routes.test.js
@@ -1,5 +1,19 @@
-// Licensed to the Apache Software Foundation (ASF) under one or more contributor
-// license agreements; and to You under the Apache License, Version 2.0.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 'use strict'
 
@@ -24,14 +38,14 @@ test.serial('create, retrieve and delete action route using token', t => {
   const routes = new Routes(new Client(options))
   const actions = new Actions(new Client(options))
 
-  return actions.create({actionName: 'routeAction', action: ''}).then(() => {
+  return actions.create({ actionName: 'routeAction', action: '' }).then(() => {
     return routes.create({
       action: 'routeAction',
       basepath: '/testing',
       relpath: '/foo/bar',
       operation: 'POST'
     }).then(() => {
-      return routes.list({basepath: '/testing'}).then(results => {
+      return routes.list({ basepath: '/testing' }).then(results => {
         t.is(results.apis.length, 1)
         const apidoc = results.apis[0].value.apidoc
         t.is(apidoc.basePath, '/testing')
@@ -40,7 +54,7 @@ test.serial('create, retrieve and delete action route using token', t => {
         t.true(path.hasOwnProperty('post'))
         t.is(path.post['x-openwhisk'].action, 'routeAction')
 
-        return routes.delete({basepath: '/testing'}).then(() => actions.delete({actionName: 'routeAction'}))
+        return routes.delete({ basepath: '/testing' }).then(() => actions.delete({ actionName: 'routeAction' }))
       })
     })
   }).catch(err => {

--- a/test/integration/rules.test.js
+++ b/test/integration/rules.test.js
@@ -1,5 +1,19 @@
-// Licensed to the Apache Software Foundation (ASF) under one or more contributor
-// license agreements; and to You under the Apache License, Version 2.0.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 'use strict'
 
@@ -39,7 +53,7 @@ test('list all rules using default namespace', t => {
 
 test('list all rules using options namespace', t => {
   const rules = new Rules(new Client(options))
-  return rules.list({namespace: NAMESPACE}).then(result => {
+  return rules.list({ namespace: NAMESPACE }).then(result => {
     t.true(Array.isArray(result))
     result.forEach(rule => {
       t.is(rule.namespace, NAMESPACE)
@@ -53,7 +67,7 @@ test('list all rules using options namespace', t => {
 
 test('get a non-existing rule, expecting 404', async t => {
   const rules = new Rules(new Client(options))
-  await rules.get({name: 'glorfindel'}).catch(err => {
+  await rules.get({ name: 'glorfindel' }).catch(err => {
     t.is(err.statusCode, 404)
   })
 })
@@ -68,8 +82,8 @@ test.serial('create, get and delete a rule', t => {
   const rules = new Rules(new Client(options))
   const triggers = new Triggers(new Client(options))
   const actions = new Actions(new Client(options))
-  return actions.create({actionName: 'hello', action: 'function main() {return {payload:"Hello world"}}'}).then(() => {
-    return triggers.create({triggerName: 'sample_rule_trigger'}).then(() => {
+  return actions.create({ actionName: 'hello', action: 'function main() {return {payload:"Hello world"}}' }).then(() => {
+    return triggers.create({ triggerName: 'sample_rule_trigger' }).then(() => {
       return rules.create({
         ruleName: 'random_rule_test',
         action: `/${NAMESPACE}/hello`,
@@ -77,16 +91,16 @@ test.serial('create, get and delete a rule', t => {
       }).then(result => {
         t.is(result.name, 'random_rule_test')
         t.is(result.namespace, NAMESPACE)
-        t.deepEqual(result.action, {path: NAMESPACE, name: 'hello'})
-        t.deepEqual(result.trigger, {path: NAMESPACE, name: 'sample_rule_trigger'})
-        return rules.get({ruleName: result.name}).then(ruleResult => {
+        t.deepEqual(result.action, { path: NAMESPACE, name: 'hello' })
+        t.deepEqual(result.trigger, { path: NAMESPACE, name: 'sample_rule_trigger' })
+        return rules.get({ ruleName: result.name }).then(ruleResult => {
           t.is(ruleResult.name, result.name)
           t.is(ruleResult.namespace, NAMESPACE)
           t.pass()
-          return rules.disable({ruleName: 'random_rule_test'})
-            .then(() => rules.delete({ruleName: 'random_rule_test'}))
-            .then(() => triggers.delete({triggerName: 'sample_rule_trigger'}))
-            .then(() => actions.delete({actionName: 'hello'}))
+          return rules.disable({ ruleName: 'random_rule_test' })
+            .then(() => rules.delete({ ruleName: 'random_rule_test' }))
+            .then(() => triggers.delete({ triggerName: 'sample_rule_trigger' }))
+            .then(() => actions.delete({ actionName: 'hello' }))
         })
       })
     })
@@ -102,12 +116,12 @@ test.serial('create and update a rule', t => {
   const rules = new Rules(new Client(options))
   const triggers = new Triggers(new Client(options))
   const actions = new Actions(new Client(options))
-  return actions.create({actionName: 'hello', action: 'function main() {return {payload:"Hello world"}}'}).then(() => {
+  return actions.create({ actionName: 'hello', action: 'function main() {return {payload:"Hello world"}}' }).then(() => {
     return actions.create({
       actionName: 'tests',
       action: 'function main() {return {payload:"Hello world"}}'
     }).then(() => {
-      return triggers.create({triggerName: 'sample_rule_trigger'}).then(() => {
+      return triggers.create({ triggerName: 'sample_rule_trigger' }).then(() => {
         return rules.create({
           ruleName: 'random_update_test',
           action: `/${NAMESPACE}/hello`,
@@ -115,20 +129,20 @@ test.serial('create and update a rule', t => {
         }).then(result => {
           t.is(result.name, 'random_update_test')
           t.is(result.namespace, NAMESPACE)
-          t.deepEqual(result.action, {path: NAMESPACE, name: 'hello'})
-          t.deepEqual(result.trigger, {path: NAMESPACE, name: 'sample_rule_trigger'})
-          return rules.disable({ruleName: 'random_update_test'}).then(() => {
+          t.deepEqual(result.action, { path: NAMESPACE, name: 'hello' })
+          t.deepEqual(result.trigger, { path: NAMESPACE, name: 'sample_rule_trigger' })
+          return rules.disable({ ruleName: 'random_update_test' }).then(() => {
             return rules.update({
               ruleName: 'random_update_test',
               action: 'tests',
               trigger: 'sample_rule_trigger'
             }).then(updateResult => {
-              t.deepEqual(updateResult.action, {path: NAMESPACE, name: 'tests'})
+              t.deepEqual(updateResult.action, { path: NAMESPACE, name: 'tests' })
               t.pass()
-              return rules.delete({ruleName: 'random_update_test'})
-                .then(() => triggers.delete({triggerName: 'sample_rule_trigger'}))
-                .then(() => actions.delete({actionName: 'hello'}))
-                .then(() => actions.delete({actionName: 'tests'}))
+              return rules.delete({ ruleName: 'random_update_test' })
+                .then(() => triggers.delete({ triggerName: 'sample_rule_trigger' }))
+                .then(() => actions.delete({ actionName: 'hello' }))
+                .then(() => actions.delete({ actionName: 'tests' }))
                 .catch(errors)
             })
           })

--- a/test/integration/triggers.test.js
+++ b/test/integration/triggers.test.js
@@ -1,5 +1,19 @@
-// Licensed to the Apache Software Foundation (ASF) under one or more contributor
-// license agreements; and to You under the Apache License, Version 2.0.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 'use strict'
 
@@ -38,7 +52,7 @@ test('list all triggers using default namespace', t => {
 
 test('list all triggers using options namespace', t => {
   const triggers = new Triggers(new Client(options))
-  return triggers.list({namespace: NAMESPACE}).then(result => {
+  return triggers.list({ namespace: NAMESPACE }).then(result => {
     t.true(Array.isArray(result))
     result.forEach(trigger => {
       t.is(trigger.namespace, NAMESPACE)
@@ -52,7 +66,7 @@ test('list all triggers using options namespace', t => {
 
 test('get a non-existing trigger, expecting 404', async t => {
   const triggers = new Triggers(new Client(options))
-  await triggers.get({name: 'glorfindel'}).catch(err => {
+  await triggers.get({ name: 'glorfindel' }).catch(err => {
     t.is(err.statusCode, 404)
   })
 })
@@ -64,18 +78,18 @@ test('create, get and delete an trigger', t => {
   }
 
   const triggers = new Triggers(new Client(options))
-  return triggers.create({triggerName: 'random_trigger_test'}).then(result => {
+  return triggers.create({ triggerName: 'random_trigger_test' }).then(result => {
     t.is(result.name, 'random_trigger_test')
     t.is(result.namespace, NAMESPACE)
     t.deepEqual(result.annotations, [])
     t.is(result.version, '0.0.1')
     t.deepEqual(result.limits, {})
     t.pass()
-    return triggers.get({triggerName: result.name}).then(triggerResult => {
+    return triggers.get({ triggerName: result.name }).then(triggerResult => {
       t.is(triggerResult.name, result.name)
       t.is(triggerResult.namespace, NAMESPACE)
       t.pass()
-      return triggers.delete({triggerName: result.name}).catch(errors)
+      return triggers.delete({ triggerName: result.name }).catch(errors)
     }).catch(errors)
   }).catch(errors)
 })
@@ -87,16 +101,16 @@ test('create and update an trigger', t => {
   }
 
   const triggers = new Triggers(new Client(options))
-  return triggers.create({triggerName: 'random_create_update_test'}).then(result => {
+  return triggers.create({ triggerName: 'random_create_update_test' }).then(result => {
     t.is(result.name, 'random_create_update_test')
     t.is(result.namespace, NAMESPACE)
     t.deepEqual(result.annotations, [])
     t.is(result.version, '0.0.1')
     t.deepEqual(result.limits, {})
-    return triggers.update({triggerName: 'random_create_update_test'}).then(updateResult => {
+    return triggers.update({ triggerName: 'random_create_update_test' }).then(updateResult => {
       t.is(updateResult.version, '0.0.2')
       t.pass()
-      return triggers.delete({triggerName: 'random_create_update_test'}).catch(errors)
+      return triggers.delete({ triggerName: 'random_create_update_test' }).catch(errors)
     }).catch(errors)
   }).catch(errors)
 })
@@ -110,13 +124,13 @@ test('fire a trigger', t => {
   const triggers = new Triggers(new Client(options))
   const rules = new Rules(new Client(options))
 
-  return triggers.create({triggerName: 'random_fire_test'}).then(() => {
-    return rules.create({ruleName: 'echo_rule', action: `/whisk.system/utils/echo`, trigger: `/${NAMESPACE}/random_fire_test`}).then(() => {
-      return triggers.invoke({triggerName: 'random_fire_test'}).then(updateResult => {
+  return triggers.create({ triggerName: 'random_fire_test' }).then(() => {
+    return rules.create({ ruleName: 'echo_rule', action: `/whisk.system/utils/echo`, trigger: `/${NAMESPACE}/random_fire_test` }).then(() => {
+      return triggers.invoke({ triggerName: 'random_fire_test' }).then(updateResult => {
         t.true(updateResult.hasOwnProperty('activationId'))
         t.pass()
-        return triggers.delete({triggerName: 'random_fire_test'})
-          .then(() => rules.delete({ruleName: 'echo_rule'}))
+        return triggers.delete({ triggerName: 'random_fire_test' })
+          .then(() => rules.delete({ ruleName: 'echo_rule' }))
       }).catch(errors)
     }).catch(errors)
   }).catch(errors)

--- a/test/integration/utils.js
+++ b/test/integration/utils.js
@@ -1,5 +1,19 @@
-// Licensed to the Apache Software Foundation (ASF) under one or more contributor
-// license agreements; and to You under the Apache License, Version 2.0.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 function getInsecureFlag () {
   return process.env['__OW_INSECURE'] === 'true'

--- a/test/unit/actions.test.js
+++ b/test/unit/actions.test.js
@@ -1,5 +1,19 @@
-// Licensed to the Apache Software Foundation (ASF) under one or more contributor
-// license agreements; and to You under the Apache License, Version 2.0.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 'use strict'
 
@@ -15,7 +29,7 @@ test('should list all actions without parameters', t => {
   client.request = (method, path, options) => {
     t.is(method, 'GET')
     t.is(path, `namespaces/${ns}/actions`)
-    t.deepEqual(options, {qs: {}})
+    t.deepEqual(options, { qs: {} })
   }
 
   return actions.list()
@@ -29,10 +43,10 @@ test('should list all actions with parameters', t => {
   client.request = (method, path, options) => {
     t.is(method, 'GET')
     t.is(path, `namespaces/custom/actions`)
-    t.deepEqual(options.qs, {skip: 100, limit: 100})
+    t.deepEqual(options.qs, { skip: 100, limit: 100 })
   }
 
-  return actions.list({namespace: 'custom', skip: 100, limit: 100})
+  return actions.list({ namespace: 'custom', skip: 100, limit: 100 })
 })
 
 test('should list all actions with parameter count', t => {
@@ -43,10 +57,10 @@ test('should list all actions with parameter count', t => {
   client.request = (method, path, options) => {
     t.is(method, 'GET')
     t.is(path, `namespaces/custom/actions`)
-    t.deepEqual(options.qs, {count: true})
+    t.deepEqual(options.qs, { count: true })
   }
 
-  return actions.list({namespace: 'custom', count: true})
+  return actions.list({ namespace: 'custom', count: true })
 })
 
 test('should retrieve action from identifier', t => {
@@ -60,7 +74,7 @@ test('should retrieve action from identifier', t => {
     t.is(path, `namespaces/${ns}/actions/12345`)
   }
 
-  return actions.get({name: '12345'})
+  return actions.get({ name: '12345' })
 })
 
 test('should retrieve action from identifier with code query parameter', t => {
@@ -78,7 +92,7 @@ test('should retrieve action from identifier with code query parameter', t => {
     t.deepEqual(options.qs, code)
   }
 
-  return actions.get({name: '12345', code: false})
+  return actions.get({ name: '12345', code: false })
 })
 
 test('should retrieve action from string identifier', t => {
@@ -106,7 +120,7 @@ test('should delete action from identifier', t => {
     t.is(path, `namespaces/${ns}/actions/12345`)
   }
 
-  return actions.delete({name: '12345'})
+  return actions.delete({ name: '12345' })
 })
 
 test('should retrieve actionName from identifier', t => {
@@ -120,7 +134,7 @@ test('should retrieve actionName from identifier', t => {
     t.is(path, `namespaces/${ns}/actions/12345`)
   }
 
-  return actions.get({actionName: '12345'})
+  return actions.get({ actionName: '12345' })
 })
 
 test('should delete action from string identifier', t => {
@@ -150,7 +164,7 @@ test('should invoke action', t => {
     t.deepEqual(options.body, {})
   }
 
-  return actions.invoke({name: '12345'})
+  return actions.invoke({ name: '12345' })
 })
 
 test('should invoke action from string identifier', t => {
@@ -179,7 +193,7 @@ test('should invoke fully qualified action', t => {
     t.deepEqual(options.body, {})
   }
 
-  return actions.invoke({name: '/custom/12345'})
+  return actions.invoke({ name: '/custom/12345' })
 })
 
 test('should invoke fully qualified action with package', t => {
@@ -194,7 +208,7 @@ test('should invoke fully qualified action with package', t => {
     t.deepEqual(options.body, {})
   }
 
-  return actions.invoke({name: '/custom/package/12345'})
+  return actions.invoke({ name: '/custom/package/12345' })
 })
 
 test('should invoke blocking action with body', t => {
@@ -206,11 +220,11 @@ test('should invoke blocking action with body', t => {
   client.request = (method, path, options) => {
     t.is(method, 'POST')
     t.is(path, `namespaces/${ns}/actions/12345`)
-    t.deepEqual(options.qs, {blocking: true})
-    t.deepEqual(options.body, {foo: 'bar'})
+    t.deepEqual(options.qs, { blocking: true })
+    t.deepEqual(options.body, { foo: 'bar' })
   }
 
-  return actions.invoke({name: '12345', blocking: true, params: {foo: 'bar'}})
+  return actions.invoke({ name: '12345', blocking: true, params: { foo: 'bar' } })
 })
 
 test('should invoke action to retrieve result', t => {
@@ -218,16 +232,16 @@ test('should invoke action to retrieve result', t => {
   const ns = '_'
   const client = {}
   const actions = new Actions(client)
-  const result = {hello: 'world'}
+  const result = { hello: 'world' }
 
   client.request = (method, path, options) => {
     t.is(method, 'POST')
     t.is(path, `namespaces/${ns}/actions/12345`)
-    t.deepEqual(options.qs, {blocking: true})
-    return Promise.resolve({response: {result}})
+    t.deepEqual(options.qs, { blocking: true })
+    return Promise.resolve({ response: { result } })
   }
 
-  return actions.invoke({name: '12345', result: true, blocking: true}).then(_result => {
+  return actions.invoke({ name: '12345', result: true, blocking: true }).then(_result => {
     t.deepEqual(_result, result)
   })
 })
@@ -237,17 +251,17 @@ test('should invoke action to retrieve result without blocking', t => {
   const ns = '_'
   const client = {}
   const actions = new Actions(client)
-  const result = {hello: 'world'}
+  const result = { hello: 'world' }
 
   client.request = (method, path, options) => {
     t.is(method, 'POST')
     t.is(path, `namespaces/${ns}/actions/12345`)
     t.deepEqual(options.qs, {})
-    return Promise.resolve({response: {result}})
+    return Promise.resolve({ response: { result } })
   }
 
-  return actions.invoke({name: '12345', result: true}).then(_result => {
-    t.deepEqual(_result, {response: {result}})
+  return actions.invoke({ name: '12345', result: true }).then(_result => {
+    t.deepEqual(_result, { response: { result } })
   })
 })
 
@@ -264,7 +278,7 @@ test('should invoke blocking action using actionName', t => {
     t.deepEqual(options.body, {})
   }
 
-  return actions.invoke({actionName: '12345'})
+  return actions.invoke({ actionName: '12345' })
 })
 
 test('create a new action', t => {
@@ -278,10 +292,10 @@ test('create a new action', t => {
     t.is(method, 'PUT')
     t.is(path, `namespaces/${ns}/actions/12345`)
     t.deepEqual(options.qs, {})
-    t.deepEqual(options.body, {exec: {kind: 'nodejs:default', code: action}})
+    t.deepEqual(options.body, { exec: { kind: 'nodejs:default', code: action } })
   }
 
-  return actions.create({name: '12345', action})
+  return actions.create({ name: '12345', action })
 })
 
 test('create a new action with custom kind', t => {
@@ -296,10 +310,10 @@ test('create a new action with custom kind', t => {
     t.is(method, 'PUT')
     t.is(path, `namespaces/${ns}/actions/12345`)
     t.deepEqual(options.qs, {})
-    t.deepEqual(options.body, {exec: {kind, code: action}})
+    t.deepEqual(options.body, { exec: { kind, code: action } })
   }
 
-  return actions.create({name: '12345', action, kind})
+  return actions.create({ name: '12345', action, kind })
 })
 
 test('create a new action with custom body', t => {
@@ -307,7 +321,7 @@ test('create a new action with custom body', t => {
   const ns = '_'
   const client = {}
   const code = 'function main() { // main function body};'
-  const action = {exec: {kind: 'swift', code: code}}
+  const action = { exec: { kind: 'swift', code: code } }
   const kind = 'custom_runtime:version'
   const actions = new Actions(client)
 
@@ -318,7 +332,7 @@ test('create a new action with custom body', t => {
     t.deepEqual(options.body, action)
   }
 
-  return actions.create({name: '12345', kind, action})
+  return actions.create({ name: '12345', kind, action })
 })
 
 test('create a new action with buffer body', t => {
@@ -332,10 +346,10 @@ test('create a new action with buffer body', t => {
     t.is(method, 'PUT')
     t.is(path, `namespaces/${ns}/actions/12345`)
     t.deepEqual(options.qs, {})
-    t.deepEqual(options.body, {exec: {kind: 'nodejs:default', code: action.toString('base64')}})
+    t.deepEqual(options.body, { exec: { kind: 'nodejs:default', code: action.toString('base64') } })
   }
 
-  return actions.create({name: '12345', action})
+  return actions.create({ name: '12345', action })
 })
 
 test('create a new action with default parameters', t => {
@@ -353,14 +367,14 @@ test('create a new action with default parameters', t => {
     t.is(path, `namespaces/${ns}/actions/12345`)
     t.deepEqual(options.qs, {})
     t.deepEqual(options.body, {
-      exec: {kind: 'nodejs:default', code: action},
+      exec: { kind: 'nodejs:default', code: action },
       parameters: [
-        {key: 'foo', value: 'bar'}
+        { key: 'foo', value: 'bar' }
       ]
     })
   }
 
-  return actions.create({name: '12345', action, params})
+  return actions.create({ name: '12345', action, params })
 })
 
 test('create a new action with annotations', t => {
@@ -377,13 +391,13 @@ test('create a new action with annotations', t => {
     t.is(method, 'PUT')
     t.is(path, `namespaces/${ns}/actions/12345`)
     t.deepEqual(options.qs, {})
-    t.deepEqual(options.body, {exec: {kind: 'nodejs:default', code: action},
+    t.deepEqual(options.body, { exec: { kind: 'nodejs:default', code: action },
       annotations: [
         { key: 'foo', value: 'bar' }
-      ]})
+      ] })
   }
 
-  return actions.create({name: '12345', action, annotations})
+  return actions.create({ name: '12345', action, annotations })
 })
 
 test('create a new action with limits', t => {
@@ -400,15 +414,15 @@ test('create a new action with limits', t => {
     t.is(method, 'PUT')
     t.is(path, `namespaces/${ns}/actions/12345`)
     t.deepEqual(options.qs, {})
-    t.deepEqual(options.body, {exec: {kind: 'nodejs:default', code: action}, limits: {timeout: 300000}})
+    t.deepEqual(options.body, { exec: { kind: 'nodejs:default', code: action }, limits: { timeout: 300000 } })
   }
 
-  return actions.create({name: '12345', action, limits})
+  return actions.create({ name: '12345', action, limits })
 })
 
 test('create an action without providing an action body', t => {
   const actions = new Actions()
-  t.throws(() => actions.create({name: '12345'}), /Missing mandatory action/)
+  t.throws(() => actions.create({ name: '12345' }), /Missing mandatory action/)
 })
 
 test('create a new action with version parameter', t => {
@@ -424,10 +438,10 @@ test('create a new action with version parameter', t => {
     t.is(method, 'PUT')
     t.is(path, `namespaces/${ns}/actions/12345`)
     t.deepEqual(options.qs, {})
-    t.deepEqual(options.body, {exec: {kind: 'nodejs:default', code: action}, version: '1.0.0'})
+    t.deepEqual(options.body, { exec: { kind: 'nodejs:default', code: action }, version: '1.0.0' })
   }
 
-  return actions.create({name: '12345', action, version})
+  return actions.create({ name: '12345', action, version })
 })
 
 test('create a new sequence action', t => {
@@ -442,10 +456,10 @@ test('create a new sequence action', t => {
     t.is(method, 'PUT')
     t.is(path, `namespaces/${ns}/actions/12345`)
     t.deepEqual(options.qs, {})
-    t.deepEqual(options.body, {exec: {kind: 'sequence', components: sequence}})
+    t.deepEqual(options.body, { exec: { kind: 'sequence', components: sequence } })
   }
 
-  return actions.create({name: '12345', sequence})
+  return actions.create({ name: '12345', sequence })
 })
 
 test('create a new sequence action with additional options', t => {
@@ -469,17 +483,17 @@ test('create a new sequence action with additional options', t => {
     t.is(method, 'PUT')
     t.is(path, `namespaces/${ns}/actions/12345`)
     t.deepEqual(options.qs, {})
-    t.deepEqual(options.body, {exec: {kind: 'sequence', components: sequence},
+    t.deepEqual(options.body, { exec: { kind: 'sequence', components: sequence },
       limits,
       parameters: [
-        {key: 'foo', value: 'bar'}
+        { key: 'foo', value: 'bar' }
       ],
       annotations: [
         { key: 'foo', value: 'bar' }
-      ]})
+      ] })
   }
 
-  return actions.create({name: '12345', sequence, annotations, params, limits})
+  return actions.create({ name: '12345', sequence, annotations, params, limits })
 })
 
 test('creating sequence action with invalid sequence parameter', t => {
@@ -487,8 +501,8 @@ test('creating sequence action with invalid sequence parameter', t => {
 
   const actions = new Actions(client)
 
-  t.throws(() => actions.create({name: '12345', sequence: 'string'}), /Invalid sequence parameter/)
-  t.throws(() => actions.create({name: '12345', sequence: { foo: 'bar' }}), /Invalid sequence parameter/)
+  t.throws(() => actions.create({ name: '12345', sequence: 'string' }), /Invalid sequence parameter/)
+  t.throws(() => actions.create({ name: '12345', sequence: { foo: 'bar' } }), /Invalid sequence parameter/)
 })
 
 test('creating sequence action with empty array', t => {
@@ -496,14 +510,14 @@ test('creating sequence action with empty array', t => {
 
   const actions = new Actions(client)
 
-  t.throws(() => actions.create({name: '12345', sequence: []}), /Invalid sequence parameter/)
+  t.throws(() => actions.create({ name: '12345', sequence: [] }), /Invalid sequence parameter/)
 })
 
 test('creating action with both sequence and action parameters', t => {
   const client = {}
   const actions = new Actions(client)
 
-  t.throws(() => actions.create({name: '12345', action: 'function main() {}', sequence: 'string'}), /Invalid options parameters/)
+  t.throws(() => actions.create({ name: '12345', action: 'function main() {}', sequence: 'string' }), /Invalid options parameters/)
 })
 
 test('should pass through requested User-Agent header', t => {
@@ -518,7 +532,7 @@ test('should pass through requested User-Agent header', t => {
     t.is(options['User-Agent'], userAgent)
   }
 
-  return actions.create({name: '12345', action, version, 'User-Agent': userAgent})
+  return actions.create({ name: '12345', action, version, 'User-Agent': userAgent })
 })
 
 test('should pass through requested User-Agent header even when __OW_USER_AGENT is set', t => {
@@ -536,7 +550,7 @@ test('should pass through requested User-Agent header even when __OW_USER_AGENT 
     delete process.env['__OW_USER_AGENT']
   }
 
-  return actions.create({name: '12345', action, version, 'User-Agent': userAgent})
+  return actions.create({ name: '12345', action, version, 'User-Agent': userAgent })
 })
 
 test('should pass through exec.image parameter', t => {
@@ -552,7 +566,7 @@ test('should pass through exec.image parameter', t => {
     t.is(options.body.exec.image, image)
   }
 
-  return actions.create({name: '12345', action, version, exec, kind: 'blackbox'})
+  return actions.create({ name: '12345', action, version, exec, kind: 'blackbox' })
 })
 
 test('should pass through exec.image parameter (for all kinds)', t => {
@@ -568,7 +582,7 @@ test('should pass through exec.image parameter (for all kinds)', t => {
     t.is(options.body.exec.image, image)
   }
 
-  return actions.create({name: '12345', action, version, exec, kind: 'xyz'})
+  return actions.create({ name: '12345', action, version, exec, kind: 'xyz' })
 })
 
 test('should not reset kind parameter when passing through exec.image parameter', t => {
@@ -584,5 +598,5 @@ test('should not reset kind parameter when passing through exec.image parameter'
     t.is(options.body.exec.kind, 'xyz')
   }
 
-  return actions.create({name: '12345', action, version, exec, kind: 'xyz'})
+  return actions.create({ name: '12345', action, version, exec, kind: 'xyz' })
 })

--- a/test/unit/activations.test.js
+++ b/test/unit/activations.test.js
@@ -1,5 +1,19 @@
-// Licensed to the Apache Software Foundation (ASF) under one or more contributor
-// license agreements; and to You under the Apache License, Version 2.0.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 'use strict'
 

--- a/test/unit/base_operation.test.js
+++ b/test/unit/base_operation.test.js
@@ -1,5 +1,19 @@
-// Licensed to the Apache Software Foundation (ASF) under one or more contributor
-// license agreements; and to You under the Apache License, Version 2.0.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 'use strict'
 
@@ -20,7 +34,7 @@ test('should invoke client request for resource', t => {
 
   const baseOperation = new BaseOperation(client)
   baseOperation.resource = resource
-  baseOperation.request({method})
+  baseOperation.request({ method })
 })
 
 test('should invoke client request for resource with identifier', t => {
@@ -38,7 +52,7 @@ test('should invoke client request for resource with identifier', t => {
 
   const baseOperation = new BaseOperation(client)
   baseOperation.resource = resource
-  baseOperation.request({method, id})
+  baseOperation.request({ method, id })
 })
 
 test('should invoke client request with user parameters', t => {
@@ -47,46 +61,46 @@ test('should invoke client request with user parameters', t => {
   const resource = 'resource_id'
   const method = 'GET'
   const id = '12345'
-  const options = {qs: {hello: 'world'}, body: {hello: 'world'}}
+  const options = { qs: { hello: 'world' }, body: { hello: 'world' } }
   const client = {
     request: (_method, _path, _options) => {
       t.is(_method, method)
       t.is(_path, `namespaces/${namespace}/${resource}/${id}`)
-      t.deepEqual(_options, {qs: {hello: 'world'}, body: {hello: 'world'}})
+      t.deepEqual(_options, { qs: { hello: 'world' }, body: { hello: 'world' } })
     }
   }
 
   const baseOperation = new BaseOperation(client)
   baseOperation.resource = resource
-  baseOperation.request({method, id, options})
+  baseOperation.request({ method, id, options })
 })
 
 test('should extract available query string parameters', t => {
   const baseOperation = new BaseOperation()
   t.deepEqual(baseOperation.qs({}, ['a', 'b', 'c']), {})
-  t.deepEqual(baseOperation.qs({a: 1}, ['a', 'b', 'c']), {a: 1})
-  t.deepEqual(baseOperation.qs({a: 1, c: 2}, ['a', 'b', 'c']), {a: 1, c: 2})
-  t.deepEqual(baseOperation.qs({a: 1, c: 2, d: 3}, ['a', 'b', 'c']), {a: 1, c: 2})
+  t.deepEqual(baseOperation.qs({ a: 1 }, ['a', 'b', 'c']), { a: 1 })
+  t.deepEqual(baseOperation.qs({ a: 1, c: 2 }, ['a', 'b', 'c']), { a: 1, c: 2 })
+  t.deepEqual(baseOperation.qs({ a: 1, c: 2, d: 3 }, ['a', 'b', 'c']), { a: 1, c: 2 })
 })
 
 test('should return appropriate namespace', t => {
   let baseOperation = new BaseOperation()
-  t.is(baseOperation.namespace({namespace: 'provided'}), 'provided')
+  t.is(baseOperation.namespace({ namespace: 'provided' }), 'provided')
 
   // using global ns
-  baseOperation = new BaseOperation({options: {namespace: 'global_ns'}})
-  t.is(baseOperation.namespace({namespace: 'provided'}), 'provided')
-  baseOperation = new BaseOperation({options: {namespace: 'global_ns'}})
+  baseOperation = new BaseOperation({ options: { namespace: 'global_ns' } })
+  t.is(baseOperation.namespace({ namespace: 'provided' }), 'provided')
+  baseOperation = new BaseOperation({ options: { namespace: 'global_ns' } })
   t.is(baseOperation.namespace({}), 'global_ns')
   t.is(baseOperation.namespace(), 'global_ns')
 
   baseOperation = new BaseOperation('default')
-  t.is(baseOperation.namespace({namespace: 'provided'}), 'provided')
+  t.is(baseOperation.namespace({ namespace: 'provided' }), 'provided')
   t.is(baseOperation.namespace(), '_')
 })
 
 test('should url encode namespace parameter', t => {
   let baseOperation = new BaseOperation('sample@path')
-  t.is(baseOperation.namespace({namespace: 'sample path'}), `sample%20path`)
-  t.is(baseOperation.namespace({namespace: 'sample@path'}), `sample%40path`)
+  t.is(baseOperation.namespace({ namespace: 'sample path' }), `sample%20path`)
+  t.is(baseOperation.namespace({ namespace: 'sample@path' }), `sample%40path`)
 })

--- a/test/unit/client.test.js
+++ b/test/unit/client.test.js
@@ -1,5 +1,19 @@
-// Licensed to the Apache Software Foundation (ASF) under one or more contributor
-// license agreements; and to You under the Apache License, Version 2.0.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 'use strict'
 
@@ -8,7 +22,7 @@ const Client = require('../../lib/client')
 const http = require('http')
 
 test('should use default constructor options', t => {
-  const client = new Client({api_key: 'aaa', apihost: 'my_host'})
+  const client = new Client({ api_key: 'aaa', apihost: 'my_host' })
   t.false(client.options.ignoreCerts)
   t.is(client.options.apiKey, 'aaa')
   t.is(client.options.apiVersion, 'v1')
@@ -101,7 +115,7 @@ test('should use options for parameters even if environment parameters are avail
   process.env['__OW_API_HOST'] = 'mywhiskhost'
   process.env['__OW_APIGW_TOKEN'] = 'my-token'
   process.env['__OW_APIGW_SPACE_GUID'] = 'my-space'
-  const client = new Client({apihost: 'openwhisk', api_key: 'mykey', apigw_token: 'token', apigw_space_guid: 'guid'})
+  const client = new Client({ apihost: 'openwhisk', api_key: 'mykey', apigw_token: 'token', apigw_space_guid: 'guid' })
   t.is(client.options.apiKey, 'mykey')
   t.is(client.options.api, 'https://openwhisk/api/v1/')
   t.is(client.options.apigwToken, 'token')
@@ -113,22 +127,22 @@ test('should use options for parameters even if environment parameters are avail
 })
 
 test('should throw error when missing API key option.', t => {
-  t.throws(() => new Client({api: true}), /Missing api_key parameter./)
+  t.throws(() => new Client({ api: true }), /Missing api_key parameter./)
 })
 
 test('should throw error when missing both API and API Host options.', t => {
-  t.throws(() => new Client({api_key: true}), /Missing either api or apihost parameters/)
+  t.throws(() => new Client({ api_key: true }), /Missing either api or apihost parameters/)
 })
 
 test('should handle multiple api parameter formats', t => {
-  const client = new Client({api_key: true, apihost: 'blah'})
+  const client = new Client({ api_key: true, apihost: 'blah' })
   t.is(client.urlFromApihost('my_host'), 'https://my_host/api/v1/')
   t.is(client.urlFromApihost('https://my_host:80'), 'https://my_host:80/api/v1/')
   t.is(client.urlFromApihost('http://my_host:80'), 'http://my_host:80/api/v1/')
 })
 
 test('should return default request parameters without options', async t => {
-  const client = new Client({api_key: 'username:password', apihost: 'blah'})
+  const client = new Client({ api_key: 'username:password', apihost: 'blah' })
   const METHOD = 'get'
   const PATH = 'some/path/to/resource'
 
@@ -143,10 +157,10 @@ test('should return default request parameters without options', async t => {
 })
 
 test('should return request parameters with merged options', async t => {
-  const client = new Client({api_key: 'username:password', apihost: 'blah'})
+  const client = new Client({ api_key: 'username:password', apihost: 'blah' })
   const METHOD = 'get'
   const PATH = 'some/path/to/resource'
-  const OPTIONS = {b: {bar: 'foo'}, a: {foo: 'bar'}}
+  const OPTIONS = { b: { bar: 'foo' }, a: { foo: 'bar' } }
 
   const params = await client.params(METHOD, PATH, OPTIONS)
   t.is(params.url, 'https://blah/api/v1/some/path/to/resource')
@@ -154,12 +168,12 @@ test('should return request parameters with merged options', async t => {
   t.true(params.json)
   t.true(params.rejectUnauthorized)
   t.true(params.headers.hasOwnProperty('Authorization'))
-  t.deepEqual(params.a, {foo: 'bar'})
-  t.deepEqual(params.b, {bar: 'foo'})
+  t.deepEqual(params.a, { foo: 'bar' })
+  t.deepEqual(params.b, { bar: 'foo' })
 })
 
 test('should return request parameters with cert and key client options', async t => {
-  const client = new Client({api_key: 'username:password', apihost: 'blah', cert: 'mycert=', key: 'mykey='})
+  const client = new Client({ api_key: 'username:password', apihost: 'blah', cert: 'mycert=', key: 'mykey=' })
   const METHOD = 'get'
   const PATH = 'some/path/to/resource'
   const OPTIONS = { myoption: true }
@@ -177,7 +191,7 @@ test('should be able to set proxy uri as client options.', async t => {
   const PATH = 'some/path/to/resource'
   const OPTIONS = {}
 
-  const client = new Client({api_key: 'username:password', apihost: 'blah', proxy: PROXY_URL})
+  const client = new Client({ api_key: 'username:password', apihost: 'blah', proxy: PROXY_URL })
   const params = await client.params(METHOD, PATH, OPTIONS)
   t.is(params.proxy, PROXY_URL)
 })
@@ -188,7 +202,7 @@ test('should be able to set http agent using client options.', async t => {
   const OPTIONS = {}
 
   const agent = new http.Agent({})
-  const client = new Client({api_key: 'username:password', apihost: 'blah', agent})
+  const client = new Client({ api_key: 'username:password', apihost: 'blah', agent })
   const params = await client.params(METHOD, PATH, OPTIONS)
   t.is(params.agent, agent)
 })
@@ -204,7 +218,7 @@ test('should be able to use env params to set proxy option.', async t => {
 
   for (let envParam of ENV_PARAMS) {
     process.env[envParam] = PROXY_URL
-    const client = new Client({api_key: 'username:password', apihost: 'blah'})
+    const client = new Client({ api_key: 'username:password', apihost: 'blah' })
     const params = await client.params(METHOD, PATH, OPTIONS)
     t.is(params.proxy, PROXY_URL, `Cannot set proxy using ${envParam}`)
     delete process.env[envParam]
@@ -212,7 +226,7 @@ test('should be able to use env params to set proxy option.', async t => {
 })
 
 test('should return request parameters with explicit api option', async t => {
-  const client = new Client({api_key: 'username:password', api: 'https://api.com/api/v1'})
+  const client = new Client({ api_key: 'username:password', api: 'https://api.com/api/v1' })
   const METHOD = 'get'
   const PATH = 'some/path/to/resource'
 
@@ -223,7 +237,7 @@ test('should return request parameters with explicit api option', async t => {
 
 test('should generate auth header from API key', async t => {
   const apiKey = 'some sample api key'
-  const client = new Client({api: true, api_key: apiKey})
+  const client = new Client({ api: true, api_key: apiKey })
   t.is(await client.authHeader(), `Basic ${Buffer.from(apiKey).toString('base64')}`)
 })
 
@@ -233,51 +247,51 @@ test('should generate auth header from 3rd party authHandler plugin', async t =>
       return Promise.resolve('Basic user:password')
     }
   }
-  const client = new Client({api: true, auth_handler: authHandler})
+  const client = new Client({ api: true, auth_handler: authHandler })
   t.is(await client.authHeader(), `Basic user:password`)
 })
 
 test('should return path and status code in error message', t => {
-  const client = new Client({api_key: true, api: true})
+  const client = new Client({ api_key: true, api: true })
   const method = 'METHOD'
   const url = 'https://blah.com/api/v1/actions/list'
   const statusCode = 400
   t.throws(() => client.handleErrors({
-    options: {method, url},
+    options: { method, url },
     statusCode
   }), `${method} ${url} Returned HTTP ${statusCode} (${http.STATUS_CODES[statusCode]}) --> "Response Missing Error Message."`)
 })
 
 test('should return response error string in error message', t => {
-  const client = new Client({api_key: true, api: true})
+  const client = new Client({ api_key: true, api: true })
   const method = 'METHOD'
   const url = 'https://blah.com/api/v1/actions/list'
   const statusCode = 400
   t.throws(() => client.handleErrors({
-    error: {error: 'hello'},
-    options: {method, url},
+    error: { error: 'hello' },
+    options: { method, url },
     statusCode
   }), `${method} ${url} Returned HTTP ${statusCode} (${http.STATUS_CODES[statusCode]}) --> "hello"`)
   t.throws(() => client.handleErrors({
-    error: {response: {result: {error: 'hello'}}},
-    options: {method, url},
+    error: { response: { result: { error: 'hello' } } },
+    options: { method, url },
     statusCode
   }), `${method} ${url} Returned HTTP ${statusCode} (${http.STATUS_CODES[statusCode]}) --> "hello"`)
   t.throws(() => client.handleErrors({
-    error: {response: {result: {error: {error: 'hello'}}}},
-    options: {method, url},
+    error: { response: { result: { error: { error: 'hello' } } } },
+    options: { method, url },
     statusCode
   }), `${method} ${url} Returned HTTP ${statusCode} (${http.STATUS_CODES[statusCode]}) --> "hello"`)
   t.throws(() => client.handleErrors({
-    error: {response: {result: {error: {statusCode: 404}}}},
-    options: {method, url},
+    error: { response: { result: { error: { statusCode: 404 } } } },
+    options: { method, url },
     statusCode
   }), `${method} ${url} Returned HTTP ${statusCode} (${http.STATUS_CODES[statusCode]}) --> "application error, status code: ${404}"`)
 })
 
 test('should throw errors for non-HTTP response failures', t => {
-  const client = new Client({api_key: true, api: true})
-  t.throws(() => client.handleErrors({message: 'error message'}), /error message/)
+  const client = new Client({ api_key: true, api: true })
+  t.throws(() => client.handleErrors({ message: 'error message' }), /error message/)
 })
 
 test('should contain x-namespace-id header when namespace in contructor options', async t => {
@@ -286,7 +300,7 @@ test('should contain x-namespace-id header when namespace in contructor options'
       return Promise.resolve('Bearer access_token')
     }
   }
-  const client = new Client({apihost: 'my_host', namespace: 'ns', auth_handler: authHandler})
+  const client = new Client({ apihost: 'my_host', namespace: 'ns', auth_handler: authHandler })
   const METHOD = 'POST'
   const PATH = '/publicnamespace/path/to/resource'
   let params = await client.params(METHOD, PATH, {})
@@ -300,7 +314,7 @@ test('should not contain x-namespace-id header when namespace is not in contruct
       return Promise.resolve('Bearer access_token')
     }
   }
-  const client = new Client({apihost: 'my_host', auth_handler: authHandler})
+  const client = new Client({ apihost: 'my_host', auth_handler: authHandler })
   const METHOD = 'POST'
   const PATH = '/publicnamespace/path/to/resource'
   let params = await client.params(METHOD, PATH, {})

--- a/test/unit/feeds.test.js
+++ b/test/unit/feeds.test.js
@@ -1,5 +1,19 @@
-// Licensed to the Apache Software Foundation (ASF) under one or more contributor
-// license agreements; and to You under the Apache License, Version 2.0.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 'use strict'
 
@@ -11,7 +25,7 @@ test('should be able to delete feed', t => {
   const apiKey = 'username:password'
   const triggerName = '/trigger_ns/triggerName'
   const client = {}
-  client.options = {apiKey: apiKey}
+  client.options = { apiKey: apiKey }
 
   const ns = '_'
   const feeds = new Feeds(client)
@@ -19,7 +33,7 @@ test('should be able to delete feed', t => {
   client.request = (method, path, options) => {
     t.is(method, 'POST')
     t.is(path, `namespaces/${ns}/actions/${feedName}`)
-    t.deepEqual(options.qs, {blocking: true})
+    t.deepEqual(options.qs, { blocking: true })
     t.deepEqual(options.body, {
       authKey: client.options.apiKey,
       lifecycleEvent: 'DELETE',
@@ -29,7 +43,7 @@ test('should be able to delete feed', t => {
 
   t.plan(4)
 
-  return feeds.delete({name: feedName, trigger: triggerName})
+  return feeds.delete({ name: feedName, trigger: triggerName })
 })
 
 test('should be able to delete feed using feedName with params', t => {
@@ -37,7 +51,7 @@ test('should be able to delete feed using feedName with params', t => {
   const apiKey = 'username:password'
   const triggerName = 'triggerName'
   const client = {}
-  client.options = {apiKey: apiKey}
+  client.options = { apiKey: apiKey }
 
   const ns = '_'
   const feeds = new Feeds(client)
@@ -45,7 +59,7 @@ test('should be able to delete feed using feedName with params', t => {
   client.request = (method, path, options) => {
     t.is(method, 'POST')
     t.is(path, `namespaces/${ns}/actions/${feedName}`)
-    t.deepEqual(options.qs, {blocking: true})
+    t.deepEqual(options.qs, { blocking: true })
     t.deepEqual(options.body, {
       foo: 'bar',
       authKey: client.options.apiKey,
@@ -56,8 +70,8 @@ test('should be able to delete feed using feedName with params', t => {
 
   t.plan(4)
 
-  const params = {foo: 'bar'}
-  return feeds.delete({feedName: feedName, trigger: triggerName, params})
+  const params = { foo: 'bar' }
+  return feeds.delete({ feedName: feedName, trigger: triggerName, params })
 })
 
 test('should be able to create feed', t => {
@@ -65,7 +79,7 @@ test('should be able to create feed', t => {
   const apiKey = 'username:password'
   const triggerName = '/trigger_ns/triggerName'
   const client = {}
-  client.options = {apiKey: apiKey}
+  client.options = { apiKey: apiKey }
 
   const ns = '_'
   const feeds = new Feeds(client)
@@ -73,7 +87,7 @@ test('should be able to create feed', t => {
   client.request = (method, path, options) => {
     t.is(method, 'POST')
     t.is(path, `namespaces/${ns}/actions/${feedName}`)
-    t.deepEqual(options.qs, {blocking: true})
+    t.deepEqual(options.qs, { blocking: true })
     t.deepEqual(options.body, {
       authKey: client.options.apiKey,
       lifecycleEvent: 'CREATE',
@@ -83,7 +97,7 @@ test('should be able to create feed', t => {
 
   t.plan(4)
 
-  return feeds.create({name: feedName, trigger: triggerName})
+  return feeds.create({ name: feedName, trigger: triggerName })
 })
 
 test('should be able to create trigger ignoring global namespace', t => {
@@ -91,7 +105,7 @@ test('should be able to create trigger ignoring global namespace', t => {
   const apiKey = 'username:password'
   const triggerName = '/a/triggerName'
   const client = {}
-  client.options = {apiKey: apiKey, namespace: 'global_ns'}
+  client.options = { apiKey: apiKey, namespace: 'global_ns' }
 
   const ns = 'global_ns'
   const feeds = new Feeds(client)
@@ -99,7 +113,7 @@ test('should be able to create trigger ignoring global namespace', t => {
   client.request = (method, path, options) => {
     t.is(method, 'POST')
     t.is(path, `namespaces/${ns}/actions/${feedName}`)
-    t.deepEqual(options.qs, {blocking: true})
+    t.deepEqual(options.qs, { blocking: true })
     t.deepEqual(options.body, {
       authKey: client.options.apiKey,
       lifecycleEvent: 'CREATE',
@@ -109,7 +123,7 @@ test('should be able to create trigger ignoring global namespace', t => {
 
   t.plan(4)
 
-  return feeds.create({name: feedName, trigger: triggerName})
+  return feeds.create({ name: feedName, trigger: triggerName })
 })
 
 test('should be able to create trigger using global namespace', t => {
@@ -117,7 +131,7 @@ test('should be able to create trigger using global namespace', t => {
   const apiKey = 'username:password'
   const triggerName = 'triggerName'
   const client = {}
-  client.options = {apiKey: apiKey, namespace: 'global_ns'}
+  client.options = { apiKey: apiKey, namespace: 'global_ns' }
 
   const ns = 'global_ns'
   const feeds = new Feeds(client)
@@ -125,7 +139,7 @@ test('should be able to create trigger using global namespace', t => {
   client.request = (method, path, options) => {
     t.is(method, 'POST')
     t.is(path, `namespaces/${ns}/actions/${feedName}`)
-    t.deepEqual(options.qs, {blocking: true})
+    t.deepEqual(options.qs, { blocking: true })
     t.deepEqual(options.body, {
       authKey: client.options.apiKey,
       lifecycleEvent: 'CREATE',
@@ -135,7 +149,7 @@ test('should be able to create trigger using global namespace', t => {
 
   t.plan(4)
 
-  return feeds.create({name: feedName, trigger: triggerName})
+  return feeds.create({ name: feedName, trigger: triggerName })
 })
 
 test('should be able to create trigger using options namespace', t => {
@@ -143,7 +157,7 @@ test('should be able to create trigger using options namespace', t => {
   const apiKey = 'username:password'
   const triggerName = 'triggerName'
   const client = {}
-  client.options = {apiKey: apiKey}
+  client.options = { apiKey: apiKey }
 
   const ns = 'custom'
   const feeds = new Feeds(client)
@@ -151,7 +165,7 @@ test('should be able to create trigger using options namespace', t => {
   client.request = (method, path, options) => {
     t.is(method, 'POST')
     t.is(path, `namespaces/${ns}/actions/${feedName}`)
-    t.deepEqual(options.qs, {blocking: true})
+    t.deepEqual(options.qs, { blocking: true })
     t.deepEqual(options.body, {
       authKey: client.options.apiKey,
       lifecycleEvent: 'CREATE',
@@ -161,7 +175,7 @@ test('should be able to create trigger using options namespace', t => {
 
   t.plan(4)
 
-  return feeds.create({name: feedName, namespace: ns, trigger: triggerName})
+  return feeds.create({ name: feedName, namespace: ns, trigger: triggerName })
 })
 
 test('should be able to create trigger ignoring options namespace', t => {
@@ -169,14 +183,14 @@ test('should be able to create trigger ignoring options namespace', t => {
   const apiKey = 'username:password'
   const triggerName = '/a/triggerName'
   const client = {}
-  client.options = {apiKey: apiKey}
+  client.options = { apiKey: apiKey }
 
   const feeds = new Feeds(client)
 
   client.request = (method, path, options) => {
     t.is(method, 'POST')
     t.is(path, `namespaces/ns/actions/${feedName}`)
-    t.deepEqual(options.qs, {blocking: true})
+    t.deepEqual(options.qs, { blocking: true })
     t.deepEqual(options.body, {
       authKey: client.options.apiKey,
       lifecycleEvent: 'CREATE',
@@ -186,7 +200,7 @@ test('should be able to create trigger ignoring options namespace', t => {
 
   t.plan(4)
 
-  return feeds.create({name: feedName, namespace: 'ns', trigger: triggerName})
+  return feeds.create({ name: feedName, namespace: 'ns', trigger: triggerName })
 })
 
 test('should be able to create trigger from full qualified feed', t => {
@@ -194,14 +208,14 @@ test('should be able to create trigger from full qualified feed', t => {
   const apiKey = 'username:password'
   const triggerName = '/a/triggerName'
   const client = {}
-  client.options = {apiKey: apiKey, namespace: 'global'}
+  client.options = { apiKey: apiKey, namespace: 'global' }
 
   const feeds = new Feeds(client)
 
   client.request = (method, path, options) => {
     t.is(method, 'POST')
     t.is(path, `namespaces/b/actions/c/feedName`)
-    t.deepEqual(options.qs, {blocking: true})
+    t.deepEqual(options.qs, { blocking: true })
     t.deepEqual(options.body, {
       authKey: client.options.apiKey,
       lifecycleEvent: 'CREATE',
@@ -211,7 +225,7 @@ test('should be able to create trigger from full qualified feed', t => {
 
   t.plan(4)
 
-  return feeds.create({name: feedName, namespace: 'ns', trigger: triggerName})
+  return feeds.create({ name: feedName, namespace: 'ns', trigger: triggerName })
 })
 
 test('should be able to create feed using feedName with params', t => {
@@ -219,7 +233,7 @@ test('should be able to create feed using feedName with params', t => {
   const apiKey = 'username:password'
   const triggerName = 'triggerName'
   const client = {}
-  client.options = {apiKey: apiKey}
+  client.options = { apiKey: apiKey }
 
   const ns = '_'
   const feeds = new Feeds(client)
@@ -227,7 +241,7 @@ test('should be able to create feed using feedName with params', t => {
   client.request = (method, path, options) => {
     t.is(method, 'POST')
     t.is(path, `namespaces/${ns}/actions/${feedName}`)
-    t.deepEqual(options.qs, {blocking: true})
+    t.deepEqual(options.qs, { blocking: true })
     t.deepEqual(options.body, {
       foo: 'bar',
       authKey: client.options.apiKey,
@@ -238,8 +252,8 @@ test('should be able to create feed using feedName with params', t => {
 
   t.plan(4)
 
-  const params = {foo: 'bar'}
-  return feeds.create({feedName: feedName, trigger: triggerName, params})
+  const params = { foo: 'bar' }
+  return feeds.create({ feedName: feedName, trigger: triggerName, params })
 })
 
 test('should be able to get feed', t => {
@@ -255,13 +269,13 @@ test('should be able to get feed', t => {
   client.request = (method, path, options) => {
     t.is(method, 'POST')
     t.is(path, `namespaces/${ns}/actions/${feedName}`)
-    t.deepEqual(options.qs, {blocking: true})
-    t.deepEqual(options.body, {authKey: client.options.apiKey, lifecycleEvent: 'READ', triggerName: `${triggerName}`})
+    t.deepEqual(options.qs, { blocking: true })
+    t.deepEqual(options.body, { authKey: client.options.apiKey, lifecycleEvent: 'READ', triggerName: `${triggerName}` })
   }
 
   t.plan(4)
 
-  return feeds.get({name: feedName, trigger: triggerName})
+  return feeds.get({ name: feedName, trigger: triggerName })
 })
 
 test('should be able to update feed', t => {
@@ -277,23 +291,23 @@ test('should be able to update feed', t => {
   client.request = (method, path, options) => {
     t.is(method, 'POST')
     t.is(path, `namespaces/${ns}/actions/${feedName}`)
-    t.deepEqual(options.qs, {blocking: true})
-    t.deepEqual(options.body, {authKey: client.options.apiKey, lifecycleEvent: 'UPDATE', triggerName: `${triggerName}`})
+    t.deepEqual(options.qs, { blocking: true })
+    t.deepEqual(options.body, { authKey: client.options.apiKey, lifecycleEvent: 'UPDATE', triggerName: `${triggerName}` })
   }
 
   t.plan(4)
 
-  return feeds.update({name: feedName, trigger: triggerName})
+  return feeds.update({ name: feedName, trigger: triggerName })
 })
 
 test('should throw errors without trigger parameter ', t => {
-  const client = {options: {}}
+  const client = { options: {} }
   const feeds = new Feeds(client)
-  t.throws(() => feeds.feed('', {feedName: 'myFeed'}), /trigger/)
+  t.throws(() => feeds.feed('', { feedName: 'myFeed' }), /trigger/)
 })
 
 test('should throw errors without id parameter', t => {
-  const client = {options: {}}
+  const client = { options: {} }
   const feeds = new Feeds(client)
-  t.throws(() => feeds.feed('', {trigger: 'myFeed'}), /feedName/)
+  t.throws(() => feeds.feed('', { trigger: 'myFeed' }), /feedName/)
 })

--- a/test/unit/names.test.js
+++ b/test/unit/names.test.js
@@ -1,5 +1,19 @@
-// Licensed to the Apache Software Foundation (ASF) under one or more contributor
-// license agreements; and to You under the Apache License, Version 2.0.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 'use strict'
 

--- a/test/unit/namespaces.test.js
+++ b/test/unit/namespaces.test.js
@@ -1,5 +1,19 @@
-// Licensed to the Apache Software Foundation (ASF) under one or more contributor
-// license agreements; and to You under the Apache License, Version 2.0.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 'use strict'
 
@@ -30,7 +44,7 @@ test('should list all namespaces, passing through user-agent header', t => {
   }
 
   const namespaces = new Namespaces(client)
-  return namespaces.list({'User-Agent': userAgent})
+  return namespaces.list({ 'User-Agent': userAgent })
 })
 
 test('should list all namespaces, NOT passing through user-agent header (variant 1)', t => {
@@ -41,12 +55,12 @@ test('should list all namespaces, NOT passing through user-agent header (variant
     t.is(method, 'GET')
     t.is(path, `namespaces`)
 
-    const parms = await new Client({api: 'aaa', api_key: 'aaa'}).params(method, path, options)
+    const parms = await new Client({ api: 'aaa', api_key: 'aaa' }).params(method, path, options)
     t.is(parms.headers['User-Agent'], undefined)
   }
 
   const namespaces = new Namespaces(client)
-  return namespaces.list({'User-Agent': userAgent, noUserAgent: true})
+  return namespaces.list({ 'User-Agent': userAgent, noUserAgent: true })
 })
 
 test('should list all namespaces, NOT passing through user-agent header (variant 2)', t => {
@@ -57,12 +71,12 @@ test('should list all namespaces, NOT passing through user-agent header (variant
     t.is(method, 'GET')
     t.is(path, `namespaces`)
 
-    const parms = await new Client({api: 'aaa', api_key: 'aaa', noUserAgent: true}).params(method, path, options)
+    const parms = await new Client({ api: 'aaa', api_key: 'aaa', noUserAgent: true }).params(method, path, options)
     t.is(parms.headers['User-Agent'], undefined)
   }
 
   const namespaces = new Namespaces(client)
-  return namespaces.list({'User-Agent': userAgent})
+  return namespaces.list({ 'User-Agent': userAgent })
 })
 
 test('should list all namespaces, NOT passing through user-agent header (variant 3)', t => {
@@ -72,7 +86,7 @@ test('should list all namespaces, NOT passing through user-agent header (variant
     t.is(method, 'GET')
     t.is(path, `namespaces`)
 
-    const parms = await new Client({api: 'aaa', api_key: 'aaa', noUserAgent: true}).params(method, path, options)
+    const parms = await new Client({ api: 'aaa', api_key: 'aaa', noUserAgent: true }).params(method, path, options)
     t.is(parms.headers['User-Agent'], undefined)
   }
 
@@ -90,7 +104,7 @@ test('should list all namespaces, NOT passing through user-agent header (variant
   }
 
   const namespaces = new Namespaces(client)
-  return namespaces.list({noUserAgent: true})
+  return namespaces.list({ noUserAgent: true })
 })
 
 test('should list all namespaces, using __OW_USER_AGENT', t => {
@@ -101,7 +115,7 @@ test('should list all namespaces, using __OW_USER_AGENT', t => {
     t.is(method, 'GET')
     t.is(path, `namespaces`)
 
-    const parms = await new Client({api: 'aaa', api_key: 'aaa'}).params(method, path, options)
+    const parms = await new Client({ api: 'aaa', api_key: 'aaa' }).params(method, path, options)
     t.is(parms.headers['User-Agent'], 'my-useragent')
     delete process.env['__OW_USER_AGENT']
   }
@@ -118,7 +132,7 @@ test('should list all namespaces, NOT using __OW_USER_AGENT when noUserAgent tru
     t.is(method, 'GET')
     t.is(path, `namespaces`)
 
-    const parms = await new Client({api: 'aaa', api_key: 'aaa', noUserAgent: true}).params(method, path, options)
+    const parms = await new Client({ api: 'aaa', api_key: 'aaa', noUserAgent: true }).params(method, path, options)
     t.is(parms.headers['User-Agent'], undefined)
     delete process.env['__OW_USER_AGENT']
   }
@@ -136,13 +150,13 @@ test('should list all namespaces, NOT using __OW_USER_AGENT when user-agent is p
     t.is(method, 'GET')
     t.is(path, `namespaces`)
 
-    const parms = await new Client({api: 'aaa', api_key: 'aaa'}).params(method, path, options)
+    const parms = await new Client({ api: 'aaa', api_key: 'aaa' }).params(method, path, options)
     t.is(parms.headers['User-Agent'], userAgent)
     delete process.env['__OW_USER_AGENT']
   }
 
   const namespaces = new Namespaces(client)
-  return namespaces.list({'User-Agent': userAgent})
+  return namespaces.list({ 'User-Agent': userAgent })
 })
 
 test('should list all namespaces, NOT using __OW_USER_AGENT or user-agent when noUserAgent is true', t => {
@@ -154,13 +168,13 @@ test('should list all namespaces, NOT using __OW_USER_AGENT or user-agent when n
     t.is(method, 'GET')
     t.is(path, `namespaces`)
 
-    const parms = await new Client({api: 'aaa', api_key: 'aaa', noUserAgent: true}).params(method, path, options)
+    const parms = await new Client({ api: 'aaa', api_key: 'aaa', noUserAgent: true }).params(method, path, options)
     t.is(parms.headers['User-Agent'], undefined)
     delete process.env['__OW_USER_AGENT']
   }
 
   const namespaces = new Namespaces(client)
-  return namespaces.list({'User-Agent': userAgent})
+  return namespaces.list({ 'User-Agent': userAgent })
 })
 
 test('should retrieve namespace entities', t => {
@@ -192,5 +206,5 @@ test('should retrieve namespace entities, passing through user-agent header', t 
   }
 
   const namespaces = new Namespaces(client)
-  return namespaces.get({'User-Agent': userAgent})
+  return namespaces.get({ 'User-Agent': userAgent })
 })

--- a/test/unit/packages.test.js
+++ b/test/unit/packages.test.js
@@ -1,5 +1,19 @@
-// Licensed to the Apache Software Foundation (ASF) under one or more contributor
-// license agreements; and to You under the Apache License, Version 2.0.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 'use strict'
 
@@ -15,7 +29,7 @@ test('should list all packages without parameters', t => {
   client.request = (method, path, options) => {
     t.is(method, 'GET')
     t.is(path, `namespaces/${ns}/packages`)
-    t.deepEqual(options, {qs: {}})
+    t.deepEqual(options, { qs: {} })
   }
 
   return packages.list()
@@ -29,10 +43,10 @@ test('should list all packages with parameters', t => {
   client.request = (method, path, options) => {
     t.is(method, 'GET')
     t.is(path, `namespaces/custom/packages`)
-    t.deepEqual(options.qs, {skip: 100, limit: 100})
+    t.deepEqual(options.qs, { skip: 100, limit: 100 })
   }
 
-  return packages.list({namespace: 'custom', skip: 100, limit: 100})
+  return packages.list({ namespace: 'custom', skip: 100, limit: 100 })
 })
 
 test('should list all packages with parameter count', t => {
@@ -43,10 +57,10 @@ test('should list all packages with parameter count', t => {
   client.request = (method, path, options) => {
     t.is(method, 'GET')
     t.is(path, `namespaces/custom/packages`)
-    t.deepEqual(options.qs, {count: true})
+    t.deepEqual(options.qs, { count: true })
   }
 
-  return packages.list({namespace: 'custom', count: true})
+  return packages.list({ namespace: 'custom', count: true })
 })
 
 test('should retrieve package from string identifier', t => {
@@ -74,7 +88,7 @@ test('should retrieve package from identifier', t => {
     t.is(path, `namespaces/${ns}/packages/12345`)
   }
 
-  return packages.get({name: '12345'})
+  return packages.get({ name: '12345' })
 })
 
 test('should retrieve package from packageName identifier', t => {
@@ -88,7 +102,7 @@ test('should retrieve package from packageName identifier', t => {
     t.is(path, `namespaces/${ns}/packages/12345`)
   }
 
-  return packages.get({packageName: '12345'})
+  return packages.get({ packageName: '12345' })
 })
 
 test('should delete package from string identifier', t => {
@@ -116,7 +130,7 @@ test('should delete package from identifier', t => {
     t.is(path, `namespaces/${ns}/packages/12345`)
   }
 
-  return packages.delete({name: '12345'})
+  return packages.delete({ name: '12345' })
 })
 
 test('should throw error trying to invoke package', t => {
@@ -155,7 +169,7 @@ test('should create a new package', t => {
     t.deepEqual(options.body, {})
   }
 
-  return packages.create({name: id})
+  return packages.create({ name: id })
 })
 
 test('should create a new package with parameters', t => {
@@ -163,7 +177,7 @@ test('should create a new package with parameters', t => {
   const ns = '_'
   const client = {}
   const packages = new Packages(client)
-  const pkg = {foo: 'bar'}
+  const pkg = { foo: 'bar' }
 
   const id = '12345'
 
@@ -173,7 +187,7 @@ test('should create a new package with parameters', t => {
     t.deepEqual(options.body, pkg)
   }
 
-  return packages.create({name: id, 'package': pkg})
+  return packages.create({ name: id, 'package': pkg })
 })
 
 test('should update an existing package', t => {
@@ -187,9 +201,9 @@ test('should update an existing package', t => {
   client.request = (method, path, options) => {
     t.is(method, 'PUT')
     t.is(path, `namespaces/${ns}/packages/${id}`)
-    t.deepEqual(options.qs, {overwrite: true})
+    t.deepEqual(options.qs, { overwrite: true })
     t.deepEqual(options.body, {})
   }
 
-  return packages.update({name: id})
+  return packages.update({ name: id })
 })

--- a/test/unit/resources.test.js
+++ b/test/unit/resources.test.js
@@ -1,5 +1,19 @@
-// Licensed to the Apache Software Foundation (ASF) under one or more contributor
-// license agreements; and to You under the Apache License, Version 2.0.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 'use strict'
 
@@ -26,7 +40,7 @@ test('should send HTTP GET request with id for retrieving resource', t => {
     return Promise.resolve()
   }
 
-  return resources.get({name: '12345'})
+  return resources.get({ name: '12345' })
 })
 
 test('should send HTTP GET request with string id for retrieving resource', t => {
@@ -50,7 +64,7 @@ test('should send HTTP POST request with id for invoking resource', t => {
     return Promise.resolve()
   }
 
-  return resources.invoke({name: '12345'})
+  return resources.invoke({ name: '12345' })
 })
 
 test('should send HTTP POST request with string id for invoking resource', t => {
@@ -74,7 +88,7 @@ test('should send HTTP PUT request with id for creating resource', t => {
     return Promise.resolve()
   }
 
-  return resources.create({name: '12345'})
+  return resources.create({ name: '12345' })
 })
 
 test('should send HTTP PUT request with string id for creating resource', t => {
@@ -99,7 +113,7 @@ test('should send HTTP PUT request with id and overwrite for updating resource',
     return Promise.resolve()
   }
 
-  return resources.update({name: '12345'})
+  return resources.update({ name: '12345' })
 })
 
 test('should send HTTP PUT request with string id and overwrite for updating resource', t => {
@@ -124,7 +138,7 @@ test('should send HTTP DELETE request with id for removing resource', t => {
     return Promise.resolve()
   }
 
-  return resources.delete({name: '12345'})
+  return resources.delete({ name: '12345' })
 })
 
 test('should send HTTP DELETE request with string id for removing resource', t => {
@@ -149,7 +163,7 @@ test('should send multiple requests for array parameters', t => {
     return Promise.resolve()
   }
 
-  return resources.operationWithId('GET', [name, {name}, name, {name}, name])
+  return resources.operationWithId('GET', [name, { name }, name, { name }, name])
     .then(result => {
       t.is(result.length, 5)
     })
@@ -171,10 +185,10 @@ test('should parse action name from identifier', t => {
   const nsId = '/ns/12345'
   const nsPackageId = '/ns/package/12345'
 
-  t.is(resources.parseId({name: id}), id)
-  t.is(resources.parseId({name: nsId}), id)
-  t.is(resources.parseId({name: nsPackageId}), `package/12345`)
-  t.throws(() => resources.parseId({name: '/ns'}), /Invalid resource/)
+  t.is(resources.parseId({ name: id }), id)
+  t.is(resources.parseId({ name: nsId }), id)
+  t.is(resources.parseId({ name: nsPackageId }), `package/12345`)
+  t.throws(() => resources.parseId({ name: '/ns' }), /Invalid resource/)
 })
 
 test('should parse namespace from identifier and options', t => {
@@ -183,10 +197,10 @@ test('should parse namespace from identifier and options', t => {
   const nsName = '/ns/12345'
   const nsPackageName = '/ns/package/12345'
 
-  t.falsy(resources.parseNamespace({name}))
-  t.is(resources.parseNamespace({name: nsName}), 'ns')
-  t.is(resources.parseNamespace({name: nsPackageName}), 'ns')
-  t.is(resources.parseNamespace({name, namespace: 'custom'}), 'custom')
-  t.is(resources.parseNamespace({name: nsName, namespace: 'custom'}), 'ns')
-  t.is(resources.parseNamespace({name: nsPackageName, namespace: 'custom'}), 'ns')
+  t.falsy(resources.parseNamespace({ name }))
+  t.is(resources.parseNamespace({ name: nsName }), 'ns')
+  t.is(resources.parseNamespace({ name: nsPackageName }), 'ns')
+  t.is(resources.parseNamespace({ name, namespace: 'custom' }), 'custom')
+  t.is(resources.parseNamespace({ name: nsName, namespace: 'custom' }), 'ns')
+  t.is(resources.parseNamespace({ name: nsPackageName, namespace: 'custom' }), 'ns')
 })

--- a/test/unit/routes.test.js
+++ b/test/unit/routes.test.js
@@ -1,5 +1,19 @@
-// Licensed to the Apache Software Foundation (ASF) under one or more contributor
-// license agreements; and to You under the Apache License, Version 2.0.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 'use strict'
 
@@ -8,28 +22,28 @@ const Routes = require('../../lib/routes')
 
 test('should retrieve routes from name', t => {
   t.plan(3)
-  const client = {options: {}}
+  const client = { options: {} }
   client.request = (method, path, options) => {
     t.is(method, 'GET')
     t.is(path, routes.routeMgmtApiPath('getApi'))
-    t.deepEqual(options.qs, {basepath: 'testing'})
+    t.deepEqual(options.qs, { basepath: 'testing' })
   }
 
   const routes = new Routes(client)
-  return routes.get({name: 'testing'})
+  return routes.get({ name: 'testing' })
 })
 
 test('should retrieve routes from basepath', t => {
   t.plan(3)
-  const client = {options: {}}
+  const client = { options: {} }
   client.request = (method, path, options) => {
     t.is(method, 'GET')
     t.is(path, routes.routeMgmtApiPath('getApi'))
-    t.deepEqual(options.qs, {basepath: 'testing'})
+    t.deepEqual(options.qs, { basepath: 'testing' })
   }
 
   const routes = new Routes(client)
-  return routes.get({basepath: 'testing'})
+  return routes.get({ basepath: 'testing' })
 })
 
 test('should retrieve routes with apigwToken and name', t => {
@@ -43,11 +57,11 @@ test('should retrieve routes with apigwToken and name', t => {
   client.request = (method, path, options) => {
     t.is(method, 'GET')
     t.is(path, routes.routeMgmtApiPath('getApi'))
-    t.deepEqual(options.qs, {basepath: 'testing', spaceguid: 'space', accesstoken: 'token'})
+    t.deepEqual(options.qs, { basepath: 'testing', spaceguid: 'space', accesstoken: 'token' })
   }
 
   const routes = new Routes(client)
-  return routes.get({name: 'testing'})
+  return routes.get({ name: 'testing' })
 })
 
 test('should retrieve routes with apigwToken and basepath', t => {
@@ -61,25 +75,25 @@ test('should retrieve routes with apigwToken and basepath', t => {
   client.request = (method, path, options) => {
     t.is(method, 'GET')
     t.is(path, routes.routeMgmtApiPath('getApi'))
-    t.deepEqual(options.qs, {basepath: 'testing', spaceguid: 'space', accesstoken: 'token'})
+    t.deepEqual(options.qs, { basepath: 'testing', spaceguid: 'space', accesstoken: 'token' })
   }
 
   const routes = new Routes(client)
-  return routes.get({basepath: 'testing'})
+  return routes.get({ basepath: 'testing' })
 })
 
 test('get routes with incorrect parameters', t => {
-  const routes = new Routes({options: {}})
+  const routes = new Routes({ options: {} })
   t.throws(() => { routes.get() }, /Missing mandatory parameters: basepath or name/)
   t.throws(() => { routes.get({}) }, /Missing mandatory parameters: basepath or name/)
-  t.throws(() => { routes.get({basepath: 'id', name: 'id'}) }, /Invalid parameters: use basepath or name, not both/)
+  t.throws(() => { routes.get({ basepath: 'id', name: 'id' }) }, /Invalid parameters: use basepath or name, not both/)
 })
 
 // ADD NAME TO OTHER METHODS
 
 test('should list all routes', t => {
   t.plan(2)
-  const client = {options: {}}
+  const client = { options: {} }
   client.request = (method, path, options) => {
     t.is(method, 'GET')
     t.is(path, routes.routeMgmtApiPath('getApi'))
@@ -100,7 +114,7 @@ test('should list all routes with apigwToken', t => {
   client.request = (method, path, options) => {
     t.is(method, 'GET')
     t.is(path, routes.routeMgmtApiPath('getApi'))
-    t.deepEqual(options.qs, {spaceguid: 'space', accesstoken: 'token'})
+    t.deepEqual(options.qs, { spaceguid: 'space', accesstoken: 'token' })
   }
 
   const routes = new Routes(client)
@@ -109,8 +123,8 @@ test('should list all routes with apigwToken', t => {
 
 test('should list all routes with parameters including basepath', t => {
   t.plan(3)
-  const client = {options: {}}
-  const options = {basepath: '/hello', relpath: '/foo/bar', operation: 'GET', limit: 10, skip: 10}
+  const client = { options: {} }
+  const options = { basepath: '/hello', relpath: '/foo/bar', operation: 'GET', limit: 10, skip: 10 }
   client.request = (method, path, _options) => {
     t.is(method, 'GET')
     t.is(path, routes.routeMgmtApiPath('getApi'))
@@ -123,9 +137,9 @@ test('should list all routes with parameters including basepath', t => {
 
 test('should list all routes with parameters including name', t => {
   t.plan(3)
-  const client = {options: {}}
-  const options = {name: '/hello', relpath: '/foo/bar', operation: 'GET', limit: 10, skip: 10}
-  const qsOptions = {basepath: '/hello', relpath: '/foo/bar', operation: 'GET', limit: 10, skip: 10}
+  const client = { options: {} }
+  const options = { name: '/hello', relpath: '/foo/bar', operation: 'GET', limit: 10, skip: 10 }
+  const qsOptions = { basepath: '/hello', relpath: '/foo/bar', operation: 'GET', limit: 10, skip: 10 }
   client.request = (method, path, _options) => {
     t.is(method, 'GET')
     t.is(path, routes.routeMgmtApiPath('getApi'))
@@ -137,7 +151,7 @@ test('should list all routes with parameters including name', t => {
 })
 
 test('list routes providing basepath and name', t => {
-  const client = {options: {}}
+  const client = { options: {} }
   const routes = new Routes(client)
   return t.throws(() => {
     routes.list({
@@ -149,8 +163,8 @@ test('list routes providing basepath and name', t => {
 
 test('should delete a route with basepath', t => {
   t.plan(3)
-  const client = {options: {}}
-  const options = {force: true, basepath: '/hello'}
+  const client = { options: {} }
+  const options = { force: true, basepath: '/hello' }
 
   client.request = (method, path, _options) => {
     t.is(method, 'DELETE')
@@ -159,13 +173,13 @@ test('should delete a route with basepath', t => {
   }
 
   const routes = new Routes(client)
-  return routes.delete({basepath: '/hello'})
+  return routes.delete({ basepath: '/hello' })
 })
 
 test('should delete a route with name', t => {
   t.plan(3)
-  const client = {options: {}}
-  const options = {force: true, basepath: '/hello'}
+  const client = { options: {} }
+  const options = { force: true, basepath: '/hello' }
 
   client.request = (method, path, _options) => {
     t.is(method, 'DELETE')
@@ -174,7 +188,7 @@ test('should delete a route with name', t => {
   }
 
   const routes = new Routes(client)
-  return routes.delete({name: '/hello'})
+  return routes.delete({ name: '/hello' })
 })
 
 test('should delete a route with apigw token', t => {
@@ -189,17 +203,17 @@ test('should delete a route with apigw token', t => {
   client.request = (method, path, options) => {
     t.is(method, 'DELETE')
     t.is(path, routes.routeMgmtApiPath('deleteApi'))
-    t.deepEqual(options.qs, {basepath: '/hello', force: true, spaceguid: 'space', accesstoken: 'token'})
+    t.deepEqual(options.qs, { basepath: '/hello', force: true, spaceguid: 'space', accesstoken: 'token' })
   }
 
   const routes = new Routes(client)
-  return routes.delete({basepath: '/hello'})
+  return routes.delete({ basepath: '/hello' })
 })
 
 test('should delete a route with parameters', t => {
   t.plan(3)
-  const client = {options: {}}
-  const options = {force: true, basepath: '/hello', relpath: '/bar/1', operation: 'GET'}
+  const client = { options: {} }
+  const options = { force: true, basepath: '/hello', relpath: '/bar/1', operation: 'GET' }
 
   client.request = (method, path, _options) => {
     t.is(method, 'DELETE')
@@ -208,17 +222,17 @@ test('should delete a route with parameters', t => {
   }
 
   const routes = new Routes(client)
-  return routes.delete({basepath: '/hello', relpath: '/bar/1', operation: 'GET'})
+  return routes.delete({ basepath: '/hello', relpath: '/bar/1', operation: 'GET' })
 })
 
 test('delete routes without providing basepath or name', t => {
-  const client = {options: {}}
+  const client = { options: {} }
   const routes = new Routes(client)
   return t.throws(() => { routes.delete() }, /Missing mandatory parameters: basepath or name/)
 })
 
 test('delete routes providing basepath and name', t => {
-  const client = {options: {}}
+  const client = { options: {} }
   const routes = new Routes(client)
   return t.throws(() => {
     routes.delete({
@@ -232,8 +246,8 @@ test('should create a route', t => {
   t.plan(3)
   const pathUrl = path => `https://openwhisk.ng.bluemix.net/api/v1/${path}`
   const apiKey = 'username:password'
-  const clientOptions = {apiKey}
-  const client = {pathUrl, options: clientOptions}
+  const clientOptions = { apiKey }
+  const client = { pathUrl, options: clientOptions }
 
   const body = {
     apidoc: {
@@ -259,15 +273,15 @@ test('should create a route', t => {
   }
 
   const routes = new Routes(client)
-  return routes.create({relpath: '/hello', operation: 'GET', action: 'helloAction'})
+  return routes.create({ relpath: '/hello', operation: 'GET', action: 'helloAction' })
 })
 
 test('should create a route from swagger file', t => {
   t.plan(3)
   const pathUrl = path => `https://openwhisk.ng.bluemix.net/api/v1/${path}`
   const apiKey = 'username:password'
-  const clientOptions = {apiKey}
-  const client = {pathUrl, options: clientOptions}
+  const clientOptions = { apiKey }
+  const client = { pathUrl, options: clientOptions }
 
   const body = {
     apidoc: {
@@ -283,15 +297,15 @@ test('should create a route from swagger file', t => {
   }
 
   const routes = new Routes(client)
-  return routes.create({swagger: '{"hello": "world"}'})
+  return routes.create({ swagger: '{"hello": "world"}' })
 })
 
 test('should create a route with api name', t => {
   t.plan(3)
   const pathUrl = path => `https://openwhisk.ng.bluemix.net/api/v1/${path}`
   const apiKey = 'username:password'
-  const clientOptions = {apiKey}
-  const client = {pathUrl, options: clientOptions}
+  const clientOptions = { apiKey }
+  const client = { pathUrl, options: clientOptions }
 
   const body = {
     apidoc: {
@@ -318,15 +332,15 @@ test('should create a route with api name', t => {
   }
 
   const routes = new Routes(client)
-  return routes.create({relpath: '/hello', operation: 'GET', action: 'helloAction', name: 'SOME_NAME'})
+  return routes.create({ relpath: '/hello', operation: 'GET', action: 'helloAction', name: 'SOME_NAME' })
 })
 
 test('should create a route with apigwToken', t => {
   t.plan(4)
   const pathUrl = path => `https://openwhisk.ng.bluemix.net/api/v1/${path}`
   const apiKey = 'username:password'
-  const clientOptions = {apiKey, apigwToken: 'token', apigwSpaceGuid: 'space'}
-  const client = {pathUrl, options: clientOptions}
+  const clientOptions = { apiKey, apigwToken: 'token', apigwSpaceGuid: 'space' }
+  const client = { pathUrl, options: clientOptions }
 
   const body = {
     apidoc: {
@@ -349,19 +363,19 @@ test('should create a route with apigwToken', t => {
     t.is(method, 'POST')
     t.is(path, routes.routeMgmtApiPath('createApi'))
     t.deepEqual(_options.body, body)
-    t.deepEqual(_options.qs, {spaceguid: 'space', accesstoken: 'token'})
+    t.deepEqual(_options.qs, { spaceguid: 'space', accesstoken: 'token' })
   }
 
   const routes = new Routes(client)
-  return routes.create({relpath: '/hello', operation: 'GET', action: 'helloAction'})
+  return routes.create({ relpath: '/hello', operation: 'GET', action: 'helloAction' })
 })
 
 test('should create a route with response type', t => {
   t.plan(4)
   const pathUrl = path => `https://openwhisk.ng.bluemix.net/api/v1/${path}`
   const apiKey = 'username:password'
-  const clientOptions = {apiKey}
-  const client = {pathUrl, options: clientOptions}
+  const clientOptions = { apiKey }
+  const client = { pathUrl, options: clientOptions }
 
   const body = {
     apidoc: {
@@ -384,11 +398,11 @@ test('should create a route with response type', t => {
     t.is(method, 'POST')
     t.is(path, routes.routeMgmtApiPath('createApi'))
     t.deepEqual(_options.body, body)
-    t.deepEqual(_options.qs, {responsetype: 'http'})
+    t.deepEqual(_options.qs, { responsetype: 'http' })
   }
 
   const routes = new Routes(client)
-  return routes.create({relpath: '/hello', operation: 'GET', action: 'helloAction', responsetype: 'http'})
+  return routes.create({ relpath: '/hello', operation: 'GET', action: 'helloAction', responsetype: 'http' })
 })
 
 test('should create a route with secure key', t => {
@@ -396,8 +410,8 @@ test('should create a route with secure key', t => {
   const pathUrl = path => `https://openwhisk.ng.bluemix.net/api/v1/${path}`
   const apiKey = 'username:password'
   const secureKey = 'some_key'
-  const clientOptions = {apiKey}
-  const client = {pathUrl, options: clientOptions}
+  const clientOptions = { apiKey }
+  const client = { pathUrl, options: clientOptions }
 
   const body = {
     apidoc: {
@@ -424,15 +438,15 @@ test('should create a route with secure key', t => {
   }
 
   const routes = new Routes(client)
-  return routes.create({relpath: '/hello', operation: 'GET', action: 'helloAction', secure_key: secureKey})
+  return routes.create({ relpath: '/hello', operation: 'GET', action: 'helloAction', secure_key: secureKey })
 })
 
 test('should create a route with apigwToken and action with package', t => {
   t.plan(4)
   const pathUrl = path => `https://openwhisk.ng.bluemix.net/api/v1/${path}`
   const apiKey = 'username:password'
-  const clientOptions = {apiKey, apigwToken: 'token', apigwSpaceGuid: 'space'}
-  const client = {pathUrl, options: clientOptions}
+  const clientOptions = { apiKey, apigwToken: 'token', apigwSpaceGuid: 'space' }
+  const client = { pathUrl, options: clientOptions }
 
   const body = {
     apidoc: {
@@ -455,19 +469,19 @@ test('should create a route with apigwToken and action with package', t => {
     t.is(method, 'POST')
     t.is(path, routes.routeMgmtApiPath('createApi'))
     t.deepEqual(_options.body, body)
-    t.deepEqual(_options.qs, {spaceguid: 'space', accesstoken: 'token'})
+    t.deepEqual(_options.qs, { spaceguid: 'space', accesstoken: 'token' })
   }
 
   const routes = new Routes(client)
-  return routes.create({relpath: '/hello', operation: 'GET', action: 'package/helloAction'})
+  return routes.create({ relpath: '/hello', operation: 'GET', action: 'package/helloAction' })
 })
 
 test('should create a route with apigwToken and action with package & ns', t => {
   t.plan(4)
   const pathUrl = path => `https://openwhisk.ng.bluemix.net/api/v1/${path}`
   const apiKey = 'username:password'
-  const clientOptions = {apiKey, apigwToken: 'token', apigwSpaceGuid: 'space'}
-  const client = {pathUrl, options: clientOptions}
+  const clientOptions = { apiKey, apigwToken: 'token', apigwSpaceGuid: 'space' }
+  const client = { pathUrl, options: clientOptions }
 
   const body = {
     apidoc: {
@@ -490,19 +504,19 @@ test('should create a route with apigwToken and action with package & ns', t => 
     t.is(method, 'POST')
     t.is(path, routes.routeMgmtApiPath('createApi'))
     t.deepEqual(_options.body, body)
-    t.deepEqual(_options.qs, {spaceguid: 'space', accesstoken: 'token'})
+    t.deepEqual(_options.qs, { spaceguid: 'space', accesstoken: 'token' })
   }
 
   const routes = new Routes(client)
-  return routes.create({relpath: '/hello', operation: 'GET', action: '/ns/package/helloAction'})
+  return routes.create({ relpath: '/hello', operation: 'GET', action: '/ns/package/helloAction' })
 })
 
 test('should create a route using global ns', t => {
   t.plan(3)
   const pathUrl = path => `https://openwhisk.ng.bluemix.net/api/v1/${path}`
   const apiKey = 'username:password'
-  const clientOptions = {apiKey, namespace: 'global_ns'}
-  const client = {pathUrl, options: clientOptions}
+  const clientOptions = { apiKey, namespace: 'global_ns' }
+  const client = { pathUrl, options: clientOptions }
 
   const body = {
     apidoc: {
@@ -528,15 +542,15 @@ test('should create a route using global ns', t => {
   }
 
   const routes = new Routes(client)
-  return routes.create({relpath: '/hello', operation: 'GET', action: 'helloAction'})
+  return routes.create({ relpath: '/hello', operation: 'GET', action: 'helloAction' })
 })
 
 test('should create a route using basepath', t => {
   t.plan(3)
   const pathUrl = path => `https://openwhisk.ng.bluemix.net/api/v1/${path}`
   const apiKey = 'username:password'
-  const clientOptions = {apiKey}
-  const client = {pathUrl, options: clientOptions}
+  const clientOptions = { apiKey }
+  const client = { pathUrl, options: clientOptions }
 
   const body = {
     apidoc: {
@@ -562,15 +576,15 @@ test('should create a route using basepath', t => {
   }
 
   const routes = new Routes(client)
-  return routes.create({basepath: '/foo', relpath: '/hello', operation: 'GET', action: 'helloAction'})
+  return routes.create({ basepath: '/foo', relpath: '/hello', operation: 'GET', action: 'helloAction' })
 })
 
 test('should create a route using fully-qualified action name', t => {
   t.plan(3)
   const pathUrl = path => `https://openwhisk.ng.bluemix.net/api/v1/${path}`
   const apiKey = 'username:password'
-  const clientOptions = {apiKey}
-  const client = {pathUrl, options: clientOptions}
+  const clientOptions = { apiKey }
+  const client = { pathUrl, options: clientOptions }
 
   const body = {
     apidoc: {
@@ -596,15 +610,15 @@ test('should create a route using fully-qualified action name', t => {
   }
 
   const routes = new Routes(client)
-  return routes.create({relpath: '/hello', operation: 'GET', action: '/test/foo/helloAction'})
+  return routes.create({ relpath: '/hello', operation: 'GET', action: '/test/foo/helloAction' })
 })
 
 test('should create a route using action name with ns', t => {
   t.plan(3)
   const pathUrl = path => `https://openwhisk.ng.bluemix.net/api/v1/${path}`
   const apiKey = 'username:password'
-  const clientOptions = {apiKey: apiKey}
-  const client = {pathUrl, options: clientOptions}
+  const clientOptions = { apiKey: apiKey }
+  const client = { pathUrl, options: clientOptions }
 
   const body = {
     apidoc: {
@@ -630,15 +644,15 @@ test('should create a route using action name with ns', t => {
   }
 
   const routes = new Routes(client)
-  return routes.create({relpath: '/hello', operation: 'GET', action: '/test/helloAction'})
+  return routes.create({ relpath: '/hello', operation: 'GET', action: '/test/helloAction' })
 })
 
 test('should create a route using action name with ns overriding defaults', t => {
   t.plan(3)
   const pathUrl = path => `https://openwhisk.ng.bluemix.net/api/v1/${path}`
   const apiKey = 'username:password'
-  const clientOptions = {apiKey, namespace: 'global'}
-  const client = {pathUrl, options: clientOptions}
+  const clientOptions = { apiKey, namespace: 'global' }
+  const client = { pathUrl, options: clientOptions }
 
   const body = {
     apidoc: {
@@ -664,15 +678,15 @@ test('should create a route using action name with ns overriding defaults', t =>
   }
 
   const routes = new Routes(client)
-  return routes.create({relpath: '/hello', operation: 'GET', action: '/test/helloAction'})
+  return routes.create({ relpath: '/hello', operation: 'GET', action: '/test/helloAction' })
 })
 
 test('should create a route with path parameters', t => {
   t.plan(3)
   const pathUrl = path => `https://openwhisk.ng.bluemix.net/api/v1/${path}`
   const apiKey = 'username:password'
-  const clientOptions = {apiKey}
-  const client = {pathUrl, options: clientOptions}
+  const clientOptions = { apiKey }
+  const client = { pathUrl, options: clientOptions }
 
   const body = {
     apidoc: {
@@ -714,7 +728,7 @@ test('should create a route with path parameters', t => {
   }
 
   const routes = new Routes(client)
-  return routes.create({relpath: '/foo/{bar}/{baz}', operation: 'GET', action: 'helloAction'})
+  return routes.create({ relpath: '/foo/{bar}/{baz}', operation: 'GET', action: 'helloAction' })
 })
 
 test('should parse path parameters', t => {
@@ -736,7 +750,7 @@ test('should parse path parameters', t => {
 test('create routes missing mandatory parameters', t => {
   const routes = new Routes()
   t.throws(() => { routes.create() }, /Missing mandatory parameters: relpath, operation, action/)
-  t.throws(() => { routes.create({relpath: true, operation: true}) }, /Missing mandatory parameters: action/)
-  t.throws(() => { routes.create({action: true, operation: true}) }, /Missing mandatory parameters: relpath/)
-  t.throws(() => { routes.create({relpath: true, action: true}) }, /Missing mandatory parameters: operation/)
+  t.throws(() => { routes.create({ relpath: true, operation: true }) }, /Missing mandatory parameters: action/)
+  t.throws(() => { routes.create({ action: true, operation: true }) }, /Missing mandatory parameters: relpath/)
+  t.throws(() => { routes.create({ relpath: true, action: true }) }, /Missing mandatory parameters: operation/)
 })

--- a/test/unit/rules.test.js
+++ b/test/unit/rules.test.js
@@ -1,5 +1,19 @@
-// Licensed to the Apache Software Foundation (ASF) under one or more contributor
-// license agreements; and to You under the Apache License, Version 2.0.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 'use strict'
 
@@ -9,13 +23,13 @@ const Rules = require('../../lib/rules')
 test('should list all rules without parameters', t => {
   t.plan(3)
   const ns = '_'
-  const client = {options: {}}
+  const client = { options: {} }
   const rules = new Rules(client)
 
   client.request = (method, path, options) => {
     t.is(method, 'GET')
     t.is(path, `namespaces/${ns}/rules`)
-    t.deepEqual(options, {qs: {}})
+    t.deepEqual(options, { qs: {} })
   }
 
   return rules.list()
@@ -23,16 +37,16 @@ test('should list all rules without parameters', t => {
 
 test('should list all rules with parameters', t => {
   t.plan(3)
-  const client = {options: {}}
+  const client = { options: {} }
   const rules = new Rules(client)
 
   client.request = (method, path, options) => {
     t.is(method, 'GET')
     t.is(path, `namespaces/custom/rules`)
-    t.deepEqual(options.qs, {skip: 100, limit: 100})
+    t.deepEqual(options.qs, { skip: 100, limit: 100 })
   }
 
-  return rules.list({namespace: 'custom', skip: 100, limit: 100})
+  return rules.list({ namespace: 'custom', skip: 100, limit: 100 })
 })
 
 test('should list all rules with parameter count', t => {
@@ -43,16 +57,16 @@ test('should list all rules with parameter count', t => {
   client.request = (method, path, options) => {
     t.is(method, 'GET')
     t.is(path, `namespaces/custom/rules`)
-    t.deepEqual(options.qs, {count: true})
+    t.deepEqual(options.qs, { count: true })
   }
 
-  return rules.list({namespace: 'custom', count: true})
+  return rules.list({ namespace: 'custom', count: true })
 })
 
 test('should retrieve rule from identifier', t => {
   t.plan(2)
   const ns = '_'
-  const client = {options: {}}
+  const client = { options: {} }
   const rules = new Rules(client)
 
   client.request = (method, path, options) => {
@@ -60,13 +74,13 @@ test('should retrieve rule from identifier', t => {
     t.is(path, `namespaces/${ns}/rules/12345`)
   }
 
-  return rules.get({name: '12345'})
+  return rules.get({ name: '12345' })
 })
 
 test('should retrieve rule from ruleName identifier', t => {
   t.plan(2)
   const ns = '_'
-  const client = {options: {}}
+  const client = { options: {} }
   const rules = new Rules(client)
 
   client.request = (method, path, options) => {
@@ -74,13 +88,13 @@ test('should retrieve rule from ruleName identifier', t => {
     t.is(path, `namespaces/${ns}/rules/12345`)
   }
 
-  return rules.get({ruleName: '12345'})
+  return rules.get({ ruleName: '12345' })
 })
 
 test('should retrieve rule from string identifier', t => {
   t.plan(2)
   const ns = '_'
-  const client = {options: {}}
+  const client = { options: {} }
   const rules = new Rules(client)
 
   client.request = (method, path, options) => {
@@ -94,7 +108,7 @@ test('should retrieve rule from string identifier', t => {
 test('should delete rule from identifier', t => {
   t.plan(2)
   const ns = '_'
-  const client = {options: {}}
+  const client = { options: {} }
   const rules = new Rules(client)
 
   client.request = (method, path, options) => {
@@ -102,13 +116,13 @@ test('should delete rule from identifier', t => {
     t.is(path, `namespaces/${ns}/rules/12345`)
   }
 
-  return rules.delete({name: '12345'})
+  return rules.delete({ name: '12345' })
 })
 
 test('should delete rule from string identifier', t => {
   t.plan(2)
   const ns = '_'
-  const client = {options: {}}
+  const client = { options: {} }
   const rules = new Rules(client)
 
   client.request = (method, path, options) => {
@@ -127,7 +141,7 @@ test('should throw error trying to invoke rule', t => {
 test('create a new rule', t => {
   t.plan(4)
   const ns = '_'
-  const client = {options: {}}
+  const client = { options: {} }
   const rules = new Rules(client)
 
   const name = '12345'
@@ -138,16 +152,16 @@ test('create a new rule', t => {
     t.is(method, 'PUT')
     t.is(path, `namespaces/${ns}/rules/${name}`)
     t.deepEqual(options.qs, {})
-    t.deepEqual(options.body, {action: `/_/${action}`, trigger: `/_/${trigger}`})
+    t.deepEqual(options.body, { action: `/_/${action}`, trigger: `/_/${trigger}` })
   }
 
-  return rules.create({name, action, trigger})
+  return rules.create({ name, action, trigger })
 })
 
 test('create a new rule using fully qualified names', t => {
   t.plan(4)
   const ns = '_'
-  const client = {options: {}}
+  const client = { options: {} }
   const rules = new Rules(client)
 
   const name = '12345'
@@ -158,38 +172,38 @@ test('create a new rule using fully qualified names', t => {
     t.is(method, 'PUT')
     t.is(path, `namespaces/${ns}/rules/${name}`)
     t.deepEqual(options.qs, {})
-    t.deepEqual(options.body, {action, trigger})
+    t.deepEqual(options.body, { action, trigger })
   }
 
-  return rules.create({name, action, trigger})
+  return rules.create({ name, action, trigger })
 })
 
 test('create a rule without providing a rule name', t => {
-  const client = {options: {}}
+  const client = { options: {} }
   const rules = new Rules(client)
   return t.throws(() => {
-    rules.create({action: '', trigger: ''})
+    rules.create({ action: '', trigger: '' })
   }, /name, ruleName/)
 })
 
 test('create a rule without providing an action name', t => {
   const rules = new Rules()
   return t.throws(() => {
-    rules.create({name: '', trigger: ''})
+    rules.create({ name: '', trigger: '' })
   }, /Missing mandatory action parameter/)
 })
 
 test('create a rule without providing a trigger name', t => {
   const rules = new Rules()
   return t.throws(() => {
-    rules.create({name: '', action: ''})
+    rules.create({ name: '', action: '' })
   }, /Missing mandatory trigger parameter/)
 })
 
 test('update existing rule', t => {
   t.plan(4)
   const ns = '_'
-  const client = {options: {}}
+  const client = { options: {} }
   const rules = new Rules(client)
 
   const name = '12345'
@@ -199,17 +213,17 @@ test('update existing rule', t => {
   client.request = (method, path, options) => {
     t.is(method, 'PUT')
     t.is(path, `namespaces/${ns}/rules/${name}`)
-    t.deepEqual(options.qs, {overwrite: true})
-    t.deepEqual(options.body, {action: `/_/${action}`, trigger: `/_/${trigger}`})
+    t.deepEqual(options.qs, { overwrite: true })
+    t.deepEqual(options.body, { action: `/_/${action}`, trigger: `/_/${trigger}` })
   }
 
-  return rules.update({name, action, trigger})
+  return rules.update({ name, action, trigger })
 })
 
 test('should enable rule', t => {
   t.plan(3)
   const ns = '_'
-  const client = {options: {}}
+  const client = { options: {} }
   const rules = new Rules(client)
 
   const name = '12345'
@@ -217,16 +231,16 @@ test('should enable rule', t => {
   client.request = (method, path, options) => {
     t.is(method, 'POST')
     t.is(path, `namespaces/${ns}/rules/${name}`)
-    t.deepEqual(options.body, {status: 'active'})
+    t.deepEqual(options.body, { status: 'active' })
   }
 
-  return rules.enable({name})
+  return rules.enable({ name })
 })
 
 test('should disable rule', t => {
   t.plan(3)
   const ns = '_'
-  const client = {options: {}}
+  const client = { options: {} }
   const rules = new Rules(client)
 
   const name = '12345'
@@ -234,14 +248,14 @@ test('should disable rule', t => {
   client.request = (method, path, options) => {
     t.is(method, 'POST')
     t.is(path, `namespaces/${ns}/rules/${name}`)
-    t.deepEqual(options.body, {status: 'inactive'})
+    t.deepEqual(options.body, { status: 'inactive' })
   }
 
-  return rules.disable({name})
+  return rules.disable({ name })
 })
 
 test('should parse correct namespace for actions names with no other namespaces', t => {
-  const client = {options: {}}
+  const client = { options: {} }
   const rules = new Rules(client)
 
   t.is(rules.convertToFqn('simple'), '/_/simple')
@@ -251,7 +265,7 @@ test('should parse correct namespace for actions names with no other namespaces'
 })
 
 test('should parse correct namespace for actions names with global namespace', t => {
-  const client = {options: {namespace: 'global'}}
+  const client = { options: { namespace: 'global' } }
   const rules = new Rules(client)
 
   t.is(rules.convertToFqn('simple'), '/global/simple')

--- a/test/unit/triggers.test.js
+++ b/test/unit/triggers.test.js
@@ -1,5 +1,19 @@
-// Licensed to the Apache Software Foundation (ASF) under one or more contributor
-// license agreements; and to You under the Apache License, Version 2.0.
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 'use strict'
 
@@ -15,7 +29,7 @@ test('should list all triggers without parameters', t => {
   client.request = (method, path, options) => {
     t.is(method, 'GET')
     t.is(path, `namespaces/${ns}/triggers`)
-    t.deepEqual(options, {qs: {}})
+    t.deepEqual(options, { qs: {} })
   }
 
   return triggers.list()
@@ -29,10 +43,10 @@ test('should list all triggers with parameters', t => {
   client.request = (method, path, options) => {
     t.is(method, 'GET')
     t.is(path, `namespaces/custom/triggers`)
-    t.deepEqual(options.qs, {skip: 100, limit: 100})
+    t.deepEqual(options.qs, { skip: 100, limit: 100 })
   }
 
-  return triggers.list({namespace: 'custom', skip: 100, limit: 100})
+  return triggers.list({ namespace: 'custom', skip: 100, limit: 100 })
 })
 
 test('should list all triggers with parameter count', t => {
@@ -43,10 +57,10 @@ test('should list all triggers with parameter count', t => {
   client.request = (method, path, options) => {
     t.is(method, 'GET')
     t.is(path, `namespaces/custom/triggers`)
-    t.deepEqual(options.qs, {count: true})
+    t.deepEqual(options.qs, { count: true })
   }
 
-  return triggers.list({namespace: 'custom', count: true})
+  return triggers.list({ namespace: 'custom', count: true })
 })
 
 test('should retrieve trigger from identifier', t => {
@@ -60,7 +74,7 @@ test('should retrieve trigger from identifier', t => {
     t.is(path, `namespaces/${ns}/triggers/12345`)
   }
 
-  return triggers.get({name: '12345'})
+  return triggers.get({ name: '12345' })
 })
 
 test('should retrieve trigger from string identifier', t => {
@@ -88,7 +102,7 @@ test('should delete trigger from identifier', t => {
     t.is(path, `namespaces/${ns}/triggers/12345`)
   }
 
-  return triggers.delete({name: '12345'})
+  return triggers.delete({ name: '12345' })
 })
 
 test('should delete trigger from string identifier', t => {
@@ -116,7 +130,7 @@ test('should retrieve triggerName from identifier', t => {
     t.is(path, `namespaces/${ns}/triggers/12345`)
   }
 
-  return triggers.get({triggerName: '12345'})
+  return triggers.get({ triggerName: '12345' })
 })
 
 test('should invoke trigger', t => {
@@ -131,7 +145,7 @@ test('should invoke trigger', t => {
     t.deepEqual(options.body, {})
   }
 
-  return triggers.invoke({name: '12345'})
+  return triggers.invoke({ name: '12345' })
 })
 
 test('should invoke trigger from string identifier', t => {
@@ -159,7 +173,7 @@ test('should invoke fully qualified trigger', t => {
     t.deepEqual(options.body, {})
   }
 
-  return triggers.invoke({name: '/custom/12345'})
+  return triggers.invoke({ name: '/custom/12345' })
 })
 
 test('should invoke fully qualified trigger with package', t => {
@@ -173,7 +187,7 @@ test('should invoke fully qualified trigger with package', t => {
     t.deepEqual(options.body, {})
   }
 
-  return triggers.invoke({name: '/custom/package/12345'})
+  return triggers.invoke({ name: '/custom/package/12345' })
 })
 
 test('should invoke trigger with body', t => {
@@ -185,10 +199,10 @@ test('should invoke trigger with body', t => {
   client.request = (method, path, options) => {
     t.is(method, 'POST')
     t.is(path, `namespaces/${ns}/triggers/12345`)
-    t.deepEqual(options.body, {foo: 'bar'})
+    t.deepEqual(options.body, { foo: 'bar' })
   }
 
-  return triggers.invoke({name: '12345', params: {foo: 'bar'}})
+  return triggers.invoke({ name: '12345', params: { foo: 'bar' } })
 })
 
 test('should invoke trigger using triggerName', t => {
@@ -203,7 +217,7 @@ test('should invoke trigger using triggerName', t => {
     t.deepEqual(options.body, {})
   }
 
-  return triggers.invoke({triggerName: '12345'})
+  return triggers.invoke({ triggerName: '12345' })
 })
 
 test('create a new trigger', t => {
@@ -219,14 +233,14 @@ test('create a new trigger', t => {
     t.deepEqual(options.body, {})
   }
 
-  return triggers.create({name: '12345'})
+  return triggers.create({ name: '12345' })
 })
 
 test('create a new trigger with custom body', t => {
   t.plan(4)
   const ns = '_'
   const client = {}
-  const trigger = {foo: 'bar'}
+  const trigger = { foo: 'bar' }
   const triggers = new Triggers(client)
 
   client.request = (method, path, options) => {
@@ -236,5 +250,5 @@ test('create a new trigger with custom body', t => {
     t.deepEqual(options.body, trigger)
   }
 
-  return triggers.create({name: '12345', trigger})
+  return triggers.create({ name: '12345', trigger })
 })

--- a/tools/travis/build.sh
+++ b/tools/travis/build.sh
@@ -1,7 +1,22 @@
 #!/bin/bash
 set -e
-# Licensed to the Apache Software Foundation (ASF) under one or more contributor
-# license agreements; and to You under the Apache License, Version 2.0.
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 
 # Build script for Travis-CI.
 
@@ -39,7 +54,7 @@ key=$(cat $WHISKDIR/ansible/files/auth.guest)
 # Test
 cd $ROOTDIR
 npm ci
-#npm run lint
+npm run lint
 
 npm run check-deps-size
 npm run coverage:unit

--- a/tools/travis/scancode.sh
+++ b/tools/travis/scancode.sh
@@ -1,8 +1,21 @@
 #!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 set -e
-
-# Licensed to the Apache Software Foundation (ASF) under one or more contributor
-# license agreements; and to You under the Apache License, Version 2.0.
 
 # Build script for Travis-CI.
 SCRIPTDIR=$(cd $(dirname "$0") && pwd)

--- a/tools/travis/setup.sh
+++ b/tools/travis/setup.sh
@@ -1,6 +1,20 @@
 #!/bin/bash
-# Licensed to the Apache Software Foundation (ASF) under one or more contributor
-# license agreements; and to You under the Apache License, Version 2.0.
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 SCRIPTDIR=$(cd $(dirname "$0") && pwd)
 HOMEDIR="$SCRIPTDIR/../../../"

--- a/tools/travis/setupscan.sh
+++ b/tools/travis/setupscan.sh
@@ -1,6 +1,20 @@
 #!/bin/bash
-# Licensed to the Apache Software Foundation (ASF) under one or more contributor
-# license agreements; and to You under the Apache License, Version 2.0.
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 SCRIPTDIR=$(cd $(dirname "$0") && pwd)
 HOMEDIR="$SCRIPTDIR/../../../"


### PR DESCRIPTION
Correct license headers in JS files with full header. Fixes #162.
This was raised in the last release vote from the mentors.

Also, ran the `standard --fix` tool to resolve all minor code lint issues discovered.

This PR has no functional changes to the code.